### PR TITLE
[PYT-278] Fix large left padding in docutils.field-list

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -409,9 +409,6 @@ article.pytorch-article {
         tr {
           th.field-name {
             font-size: rem(18px);
-            @include sphinx-full-size {
-              padding-left: rem(120px);
-            }
             white-space: nowrap;
             line-height: 1.75rem;
             color: $not_quite_black;


### PR DESCRIPTION
On large screen sizes (> 1600px) the Parameter listings in the docs had some unnecessary left padding:

![left-padding](https://user-images.githubusercontent.com/4163801/46225603-c91c0e00-c327-11e8-84cb-2a6d8f2d4bda.png)

Fix Preview: https://shiftlab.github.io/pytorch_docs/distributed.html#initialization

To replicate locally in the docs:

1. Pull down the branch and run `grunt build`
2. In your docs `docs/source/conf.py` update the html_theme_path to point to the local sphinx theme repo and remove any imports of pytorch_sphinx_theme:
```
# import pytorch_sphinx_theme
...
# html_theme_path = [pytorch_sphinx_theme.get_html_theme_path()]
html_theme_path = ["../path/to/pytorch_sphinx_theme/"]
```
3. Remove your existing pytorch_sphinx_theme package if it exists:
```
rm -rf docs/src/pytorch_sphinx_theme
```
4. Build the docs
```
# in ./docs
make clean; make html
```
5. Open the docs
```
open docs/build/html/index.html
```