### PR TITLE
[PYT-286] Fix parameter table display issues

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -404,21 +404,25 @@ article.pytorch-article {
       }
     }
     table {
-      width: 0%;
       tbody {
         tr {
           th.field-name {
             font-size: rem(18px);
-            @include sphinx-full-size {
-              padding-left: rem(120px);
-            }
             white-space: nowrap;
             line-height: 1.75rem;
             color: $not_quite_black;
+            width: 20%;
+            @include desktop {
+              width: 15%;
+            }
           }
           td.field-body {
             font-size: rem(18px);
             padding: 0.625rem;
+            width: 80%;
+            @include desktop {
+              width: 85%;
+            }
             @include sphinx-full-size {
               padding-left: rem(20px);
             }
@@ -426,6 +430,9 @@ article.pytorch-article {
             color: $not_quite_black;
             p {
               padding-left: 0px;
+            }
+            ol, ul {
+              padding-left: rem(16px);
             }
           }
         }


### PR DESCRIPTION
- Ensure table column widths are consistent in all functions, classes
- Fix Firefox issue where parameter description and list was squashed by a rogue 'width: 0%' style

![screen shot 2018-09-28 at 1 07 15 pm](https://user-images.githubusercontent.com/4163801/46225740-33cd4980-c328-11e8-969c-8168c8ab791b.png)

Fix Preview: https://shiftlab.github.io/pytorch_docs/distributed.html#initialization

(Make sure to check in Firefox)
