### PR TITLE
[PYT-281] Update table header bottom borders

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -554,7 +554,9 @@ article.pytorch-article {
       border-color: $white !important;
       table-layout: fixed;
       thead {
-        border-bottom: 2px solid $quick_start_grey;
+        tr {
+          border-bottom: 2px solid $quick_start_grey;
+        }
         th {
           font-weight: 400;
           line-height: rem(28px);


### PR DESCRIPTION
It's possible that some tables have multiple table header rows. This adds a bottom border to any table header row to avoid the rows "floating" above the table.

Floating example:
![screen shot 2018-09-28 at 3 22 32 pm](https://user-images.githubusercontent.com/4163801/46229105-6da34d80-c332-11e8-9cb2-5d4518af84cb.png)

What it should now look like:
![screen shot 2018-09-28 at 3 23 49 pm](https://user-images.githubusercontent.com/4163801/46229138-90356680-c332-11e8-80cc-194b2a976cad.png)

Live preview: https://shiftlab.github.io/pytorch_docs/distributed.html#module-torch.distributed
