### PR TITLE
[PYT-288] Fix bug in right menu resizing

### DIFF
--- a/js/side-menus.js
+++ b/js/side-menus.js
@@ -1,12 +1,16 @@
 window.sideMenus = {
-  displayRightMenu: document.querySelectorAll("#pytorch-right-menu li").length > 1,
+  rightMenuIsOnScreen: function() {
+    return document.getElementById("pytorch-content-right").offsetParent !== null;
+  },
 
   isFixedToBottom: false,
 
   bind: function() {
     sideMenus.handleLeftMenu();
 
-    if (sideMenus.displayRightMenu) {
+    var rightMenuHasLinks = document.querySelectorAll("#pytorch-right-menu li").length > 1;
+
+    if (rightMenuHasLinks) {
       // Show the right menu container
       document.getElementById("pytorch-content-right").classList.add("show");
 
@@ -29,7 +33,7 @@ window.sideMenus = {
     $(window).on('resize scroll', function(e) {
       sideMenus.handleLeftMenu();
 
-      if (sideMenus.displayRightMenu) {
+      if (sideMenus.rightMenuIsOnScreen()) {
         sideMenus.handleRightMenu();
       }
     });


### PR DESCRIPTION
- On resize to mobile the right menu goes away but we are still attempting to perform calculations on it, which throws an error.
- To reproduce the error, find a page with a right-side menu and resize to mobile. In the JS console there should be errors about not being able to read property 'top' of undefined

Live preview at: https://shiftlab.github.io/pytorch_docs/distributed.html