### PR TITLE
Tighten margins between top-level right menu items

### DIFF
--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -443,7 +443,7 @@
   }
 
   .pytorch-side-scroll > ul > li > ul > li {
-    margin-bottom: rem(22px);
+    margin-bottom: 0;
   }
 
   ul ul {


### PR DESCRIPTION
The bottom margins on the top level items in the right menu are too large- on a page with no right menu sublevels the menu items are an awkward distance away from each other. The new margins are more in line with the distance between menu items in the left menu.

Preview at https://shiftlab.github.io/pytorch_docs/

Previous:
![screen shot 2018-10-01 at 5 24 54 pm](https://user-images.githubusercontent.com/4163801/46316745-ff16f780-c59e-11e8-87fe-bc5dd29824e7.png)

New:
![screen shot 2018-10-01 at 5 25 02 pm](https://user-images.githubusercontent.com/4163801/46316757-04744200-c59f-11e8-9b8f-d6e20d168795.png)
