### PR TITLE
Tighten up large-screen (> 1600px) styles to allow more vertical space

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -34,10 +34,6 @@ html {
   @include desktop {
     font-size: 14px;
   }
-
-  @include sphinx-full-size {
-    font-size: 16px;
-  }
 }
 
 body {
@@ -694,7 +690,7 @@ article.pytorch-article {
   }
 
   @include sphinx-full-size {
-    width: $sphinx_full_width_content_width - 2;
+    width: 850px;
   }
 
   .pytorch-breadcrumbs-aside {

--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -21,8 +21,7 @@
 
   @include sphinx-full-size {
     left: auto;
-    margin-left: $desktop_menu_width + 60px;
-    padding-top: 220px;
+    margin-left: $desktop_menu_width + 30px;
     width: auto;
   }
 }
@@ -44,7 +43,7 @@
   }
 
   @include sphinx-full-size {
-    width: $sphinx_full_width_content_width;
+    width: 850px;
   }
 
   .main-content {
@@ -81,7 +80,7 @@
 
   @include sphinx-full-size {
     width: $desktop_menu_width - 70px;
-    left: 0;
+    left: 50px;
     top: 0;
   }
 }
@@ -106,7 +105,8 @@
   }
 
   @include sphinx-full-size {
-    padding-right: rem(65px);
+    padding-left: 0;
+    padding-right: rem(25px);
   }
 }
 
@@ -152,10 +152,6 @@
 
   @include sphinx-medium-size {
     margin: rem(20px) 0 rem(30px) 0;
-  }
-
-  @include sphinx-full-size {
-    margin: rem(40px) 0;
   }
 }
 
@@ -203,7 +199,7 @@
   }
 
   @include sphinx-full-size {
-    width: 410px;
+    width: 340px;
   }
 }
 
@@ -225,7 +221,7 @@
   }
 
   @include sphinx-full-size {
-    left: 1200px;
+    left: 1230px;
     width: 380px;
   }
 }
@@ -503,7 +499,7 @@
   }
 
   @include sphinx-full-size {
-    width: $desktop_menu_width + 20px;
+    width: 400px;
   }
 
   padding-top: 20px;
@@ -547,11 +543,6 @@
     padding-right: rem(30px);
     padding-left: rem(30px);
   }
-
-  @include sphinx-full-size {
-    padding-right: rem(60px);
-    padding-left: rem(60px);
-  }
 }
 
 .header-holder .main-menu {
@@ -566,7 +557,7 @@
   }
 
   @include sphinx-full-size {
-    left: 380px;
+    left: 310px;
     ul {
       padding-left: 38px;
     }
@@ -592,9 +583,8 @@
   }
 
   @include sphinx-full-size {
-    left: 420px;
-    height: $desktop_header_height;
-    padding-left: 60px;
+    left: 350px;
+    padding-left: rem(30px);
     right: 0;
     width: 100%;
   }
@@ -613,6 +603,6 @@
   }
 
   @include sphinx-full-size {
-    left: 820px;
+    left: 912px;
   }
 }

--- a/scss/shared/_variables.scss
+++ b/scss/shared/_variables.scss
@@ -19,7 +19,7 @@ $smoky_grey: #CCCDD1;
 $medium_smoky_grey: #CCCDD1;
 $code_link_color: #4974D1;
 
-$desktop_menu_width: 420px;
+$desktop_menu_width: 350px;
 
 $desktop_header_height: 90px;
 $mobile_header_height: 68px;


### PR DESCRIPTION
This removes the extra large font sizes, spacing and margins above a 1600px screen width to allow for more vertical readability.

Preview: https://shiftlab.github.io/pytorch_docs/

Comparison:

Old:
![screen shot 2018-10-01 at 4 21 23 pm](https://user-images.githubusercontent.com/4163801/46545348-21a55b00-c894-11e8-909f-bb25ccae579f.png)

New:
![screen shot 2018-10-01 at 5 31 51 pm](https://user-images.githubusercontent.com/4163801/46545357-29fd9600-c894-11e8-9e73-8c9e037183b1.png)
