### PR TITLE
Ensure default KaTeX font renders in math equations

### DIFF
--- a/scss/shared/_base_styles.scss
+++ b/scss/shared/_base_styles.scss
@@ -10,6 +10,9 @@ html {
 
 * {
   box-sizing: border-box;
+}
+
+body {
   font-family: FreightSans, Helvetica Neue, Helvetica, Arial, sans-serif;
 }
 


### PR DESCRIPTION
Preview: https://5be59c8c73f2cf29dc1dacd5--shiftlab-pytorch-docs.netlify.com

Some components in the KaTeX math equations are rendering in
the site's default font Freight Sans rather than KaTeX's default font
family.

Compare:

old:
![screen shot 2018-11-09 at 9 50 13 am](https://user-images.githubusercontent.com/4163801/48269291-3a5ddf00-e405-11e8-9a91-39eaa7561c98.png)
new:
![screen shot 2018-11-09 at 9 50 01 am](https://user-images.githubusercontent.com/4163801/48269316-477ace00-e405-11e8-9fe3-b70dec1700ac.png)

old:
![screen shot 2018-11-09 at 9 50 44 am](https://user-images.githubusercontent.com/4163801/48269329-4d70af00-e405-11e8-9632-f5952b65942c.png)
new:
![screen shot 2018-11-09 at 9 50 51 am](https://user-images.githubusercontent.com/4163801/48269340-53ff2680-e405-11e8-80c6-42d4121bcfd8.png)
