### PR TITLE
Update loading of DOCUMENTATION_OPTIONS in layout.html

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -234,20 +234,27 @@
 
   {% if not embedded %}
 
-    <script type="text/javascript">
-        var DOCUMENTATION_OPTIONS = {
-            URL_ROOT:'{{ url_root }}',
-            VERSION:'{{ release|e }}',
-            LANGUAGE:'{{ language }}',
-            COLLAPSE_INDEX:false,
-            FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }},
-            SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
-        };
-    </script>
-    {%- for scriptfile in script_files %}
-      <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
-    {%- endfor %}
+     {% if sphinx_version >= "1.8.0" %}
+       <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+       {%- for scriptfile in script_files %}
+         {{ js_tag(scriptfile) }}
+       {%- endfor %}
+     {% else %}
+       <script type="text/javascript">
+           var DOCUMENTATION_OPTIONS = {
+               URL_ROOT:'{{ url_root }}',
+               VERSION:'{{ release|e }}',
+               LANGUAGE:'{{ language }}',
+               COLLAPSE_INDEX:false,
+               FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
+               HAS_SOURCE:  {{ has_source|lower }},
+               SOURCELINK_SUFFIX: '{{ sourcelink_suffix }}'
+           };
+       </script>
+       {%- for scriptfile in script_files %}
+         <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+       {%- endfor %}
+     {% endif %}
 
   {% endif %}
 


### PR DESCRIPTION
Preview: https://5bec547f02ed8324571ec54d--shiftlab-pytorch-docs.netlify.com/

Sphinx versions >= 1.8.0 have moved the loading of the DOCUMENTATION_OPTIONS to an external file in the main layout template.

Original commit in Sphinx: https://github.com/sphinx-doc/sphinx/commit/de023f2dc0972fc398975c5614caf89149a2de16

Discussion/fix at Read the Docs theme (on which this theme was based): https://github.com/rtfd/sphinx_rtd_theme/pull/672

