### PR TITLE
Ensure that text within function blocks doesn't cover Source links

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -419,6 +419,7 @@ article.pytorch-article {
       padding: rem(8px);
       border-left: 3px solid $red_orange;
       word-wrap: break-word;
+      padding-right: 100px;
       a {
         position: absolute;
         right: 30px;
@@ -513,6 +514,19 @@ article.pytorch-article {
     dt {
       border-left: none;
       border-top: 3px solid $red_orange;
+      padding-left: 4em;
+      em.property {
+        position: absolute;
+        left: 0.5rem;
+      }
+    }
+
+    dd {
+      .docutils {
+        dt {
+          padding-left: 0.5rem;
+        }
+      }
     }
 
     em.property {
@@ -530,11 +544,18 @@ article.pytorch-article {
         border-left: 3px solid $red_orange;
         border-top: none;
       }
+      dt {
+        padding-left: 0.5rem;
+      }
     }
     .attribute {
       @extend .attribute;
       dt {
         border-top: none;
+        em.property {
+          position: relative;
+          left: 0;
+        }
       }
     }
   }


### PR DESCRIPTION
This PR ensures that the text inside of function blocks does not run into or appear too close to any Source links. Here is an example of the issue: 
<img width="689" alt="source link issue" src="https://user-images.githubusercontent.com/16585245/49381194-5d686f80-f6e1-11e8-8e00-a82eedded939.png">
Here is the updated text:
<img width="682" alt="source link fix" src="https://user-images.githubusercontent.com/16585245/49381282-8557d300-f6e1-11e8-9aae-45e194f2198a.png">
Here is preview [link](https://5c014a66fdd72a6ff5fd0ff6--shiftlab-pytorch-docs.netlify.com/) for this PR.
