### PR TITLE
Ensure that long math equations aren't cut off

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -559,6 +559,10 @@ article.pytorch-article {
       }
     }
   }
+
+  table {
+    table-layout: fixed;
+  }
 }
 
 .pytorch-article {


### PR DESCRIPTION
This PR ensures that long math equations aren't cut off/don't run into the right menu. 

Issue:
![math issue](https://user-images.githubusercontent.com/16585245/49462491-2c14a000-f7c4-11e8-910d-c2e85c498269.png)
Update:
![math fix](https://user-images.githubusercontent.com/16585245/49462499-3040bd80-f7c4-11e8-95ff-d839d393bf6f.png)