### PR TITLE
Update MathJax minScaleAdjust and remove outdated MathJax css rule

### DIFF
--- a/js/mathjax.js
+++ b/js/mathjax.js
@@ -1,12 +1,13 @@
 if (typeof window.MathJax === "object") {
   window.MathJax.Hub.Config({
       messageStyle: "none",
-      scale: 100,
       "HTML-CSS": {
           showMathMenu: false,
           linebreaks: { automatic: true, width: "container" } ,
           preferredFont: "STIX",
-          availableFonts: ["STIX","TeX"]
+          availableFonts: ["STIX","TeX"],
+          scale: 100,
+          minScaleAdjust: 100
       },
       SVG: { linebreaks: { automatic: true, width: "container" } }
    });

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -715,9 +715,6 @@ article.pytorch-article .caption {
 article.pytorch-article {
   .math {
     color: $not_quite_black;
-    .MathJax_Display {
-      font-size: rem(17px);
-    }
   }
 }
 


### PR DESCRIPTION
Preview: https://5c1420f1f7907c558e51f188--shiftlab-pytorch-tutorials.netlify.com/

Related issue: https://github.com/pytorch/pytorch/issues/15202

This sets the `minScaleAdjust` setting of the MathJax HTML-CSS output processor to be `100` by default to prevent the math from rendering too small. 

This PR also removes an outdated MathJax css rule. As a result there should no longer be any css targeting the MathJax display.