### PR TITLE
Use monospace font for function text

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -420,6 +420,16 @@ article.pytorch-article {
       border-left: 3px solid $red_orange;
       word-wrap: break-word;
       padding-right: 100px;
+
+      em.property {
+        font-family: inherit;
+      }
+
+      em, .sig-paren {
+        @include code_font_family;
+        font-size: 87.5%;
+      }
+
       a {
         position: absolute;
         right: 30px;


### PR DESCRIPTION
This PR applies the monospace font to the entire function text. It should resolve the [issue](https://github.com/pytorch/pytorch/issues/14965) where the number 0 looks like a lowercase o in the function parameters. The update can be previewed [here](https://5c13ecc8abb106d00ab95256--shiftlab-pytorch-docs.netlify.com/).