### PR TITLE
Make h2 titles title case

### DIFF
--- a/scss/shared/_article.scss
+++ b/scss/shared/_article.scss
@@ -12,10 +12,10 @@ article.pytorch-article {
   }
 
   h2 {
-    font-size: rem(24px);
+    font-size: rem(26px);
     letter-spacing: 1.33px;
     line-height: rem(32px);
-    text-transform: uppercase;
+    text-transform: capitalize;
   }
 
   h3 {


### PR DESCRIPTION
This PR changes `h2` headers to be title case rather than uppercase. The preview can be viewed [here](https://5c13e7d0055b9bd4bc5868c0--shiftlab-pytorch-docs.netlify.com/). Please note that this update will change the `h2` headers on the tutorials site to title case as well.