### PR TITLE
Remove text-transform capitalize value from h2 titles

### DIFF
--- a/scss/shared/_article.scss
+++ b/scss/shared/_article.scss
@@ -15,7 +15,7 @@ article.pytorch-article {
     font-size: rem(26px);
     letter-spacing: 1.33px;
     line-height: rem(32px);
-    text-transform: capitalize;
+    text-transform: none;
   }
 
   h3 {


### PR DESCRIPTION
This PR updates the text-transform property for h2 titles by changing its value from capitalize to none. With this update h2 titles will appear how they are entered in the docs/tutorials. For example, "Refactor Using Nn.Module" will become "Refactor using nn.Module." The update can be previewed here: https://5c3f3e0c3a47508916e615e4--shiftlab-pytorch-docs.netlify.com/.