### PR TITLE
Make logo link back to static site home page

### DIFF
--- a/scss/shared/_navigation.scss
+++ b/scss/shared/_navigation.scss
@@ -38,6 +38,7 @@
   background-size: 93px 23px;
   display: block;
   float: left;
+  z-index: 10;
 
   @include full-nav-menu-desktop {
     background-size: 108px 27px;


### PR DESCRIPTION
This PR ensures that when the PyTorch nav logo is clicked it sends users to the static site home page. The change can be previewed here: https://5c40918ef6cb6c5e20e99855--shiftlab-pytorch-docs.netlify.com/.