### PR TITLE
Update script to load Search functionality

### DIFF
--- a/pytorch_sphinx_theme/search.html
+++ b/pytorch_sphinx_theme/search.html
@@ -11,12 +11,7 @@
 {% set title = _('Search') %}
 {% set script_files = script_files + ['_static/searchtools.js'] %}
 {% block footer %}
-  <script type="text/javascript">
-    jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });
-  </script>
-  {# this is used when loading the search index using $.ajax fails,
-     such as on Chrome for documents on localhost #}
-  <script type="text/javascript" id="searchindexloader"></script>
+  <script type="text/javascript" src="{{ pathto('searchindex.js', 1) }}" defer></script>
   {{ super() }}
 {% endblock %}
 {% block body %}


### PR DESCRIPTION
This attempts to fix the `Search.loadIndex is not a function` error on the docs Search page.

A recent Sphinx update removed that function in favor of deferring the script: https://github.com/sphinx-doc/sphinx/commit/55c5168f338d6a9625c789af6c4b9ab04eb5ec93#diff-71eb2d907f122b85744ef4c3390903cb

Preview at: https://5ca2ad5168bceffc3c582d09--shiftlab-pytorch-docs.netlify.com/