### PR TITLE
Fix code formatting in notes and sphinx 2.0 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PyTorch Sphinx Theme
 
-Sphinx theme for [PyTorch Docs](PyTorch documentation — PyTorch master documentation) and [PyTorch Tutorials](https://pytorch.org/tutorials) based on the [Read the Docs Sphinx Theme](https://sphinx-rtd-theme.readthedocs.io/en/latest).
+Sphinx theme for [PyTorch Docs](https://pytorch.org/docs/master/torch.html) and [PyTorch Tutorials](https://pytorch.org/tutorials) based on the [Read the Docs Sphinx Theme](https://sphinx-rtd-theme.readthedocs.io/en/latest).
 
 ## Local Development
 

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -28,6 +28,19 @@ $sphinx_shortcuts_left_margin: 78%;
   @media screen and (min-width: $sphinx_medium_width) { @content; }
 }
 
+@mixin format-code($background) {
+  border-top: solid 2px $background;
+  background-color: $background;
+  border-bottom: solid 2px $background;
+  .pre {
+    outline: 0px;
+    padding: 0px;  // remove extra spacing on children
+  }
+  padding: 0px 3px;  // the containing `code` does proper spacing
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+}
+
 html {
   height: 100%;
   @include desktop {
@@ -255,7 +268,7 @@ article.pytorch-article {
     margin-top: rem(30px);
     margin-bottom: rem(18px);
 
-    .first {
+    .admonition-title {
       color: $white;
       letter-spacing: 1px;
       text-transform: uppercase;
@@ -281,6 +294,11 @@ article.pytorch-article {
     .pre,
     pre {
       background: $white;
+      outline: 1px solid #e9e9e9;
+    }
+
+    code {
+      @include format-code($white);
       outline: 1px solid #e9e9e9;
     }
 
@@ -341,27 +359,12 @@ article.pytorch-article {
     background: #cc2f90;
   }
 
-  .admonition {
-    .last {
-      code {
-        border-top: solid 2px $white;
-        background-color: $white;
-        border-bottom: solid 2px $white;
-        outline: $white;
-        .pre {
-          outline: 0px solid $white;
-          padding: 2px 3px;
-        }
-      }
-    }
-  }
-
   .sphx-glr-download-link-note.admonition.note,
   .reference.download.internal, .sphx-glr-signature {
     display: none;
   }
 
-  div.last {
+  div:last-child, div.last {
     margin-bottom: 0;
     padding-bottom: rem(18px);
 
@@ -370,7 +373,7 @@ article.pytorch-article {
     }
   }
 
-  p.last {
+  p:last-child, p.last {
     margin-bottom: 0;
     padding-bottom: rem(18px) !important;
   }
@@ -492,15 +495,17 @@ article.pytorch-article {
       font-size: rem(25px) !important;
       padding-left: 0;
     }
+
+    .admonition code{
+      @include format-code($white);
+      outline: 1px solid #e9e9e9;
+    }
+
     code {
       color: $not_quite_black;
-      border-top: solid 2px $light_grey;
-      background-color: $light_grey;
-      border-bottom: solid 2px $light_grey;
-      .pre {
-        padding: 2px 3px;
-      }
+      @include format-code($light_grey);
     }
+
     .viewcode-link {
       font-size: rem(14px);
       color: #979797;

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -28,15 +28,17 @@ $sphinx_shortcuts_left_margin: 78%;
   @media screen and (min-width: $sphinx_medium_width) { @content; }
 }
 
-@mixin format-code($background) {
+@mixin format-code($background, $pad: true) {
   border-top: solid 2px $background;
   background-color: $background;
   border-bottom: solid 2px $background;
-  .pre {
-    outline: 0px;
-    padding: 0px;  // remove extra spacing on children
+  @if $pad {
+    padding: 0px 3px;  // the containing `code` does proper spacing
+    .pre {
+      outline: 0px;
+      padding: 0px;  // remove extra spacing on children
+    }
   }
-  padding: 0px 3px;  // the containing `code` does proper spacing
   -webkit-box-decoration-break: clone;
   box-decoration-break: clone;
 }
@@ -244,139 +246,13 @@ article.pytorch-article {
       color: $not_quite_black;
     }
   }
+  p.caption {
+    margin-top: rem(20px);
+  }
 }
 
 article.pytorch-article .section:first-of-type h1:first-of-type {
   margin-top: 0;
-}
-
-article.pytorch-article {
-  p.caption {
-    margin-top: rem(20px);
-  }
-
-  .note,
-  .warning,
-  .tip,
-  .hint,
-  .important,
-  .caution,
-  .danger,
-  .attention,
-  .error {
-    background: $light_grey;
-    margin-top: rem(30px);
-    margin-bottom: rem(18px);
-
-    .admonition-title {
-      color: $white;
-      letter-spacing: 1px;
-      text-transform: uppercase;
-      margin-bottom: rem(18px);
-      padding: 3px 0 3px rem(22px);
-      position: relative;
-      font-size: rem(14px);
-      &:before {
-        content: "\2022";
-        position: absolute;
-        left: 9px;
-        color: $white;
-        top: 2px;
-      }
-    }
-    p:nth-child(n + 2) {
-      padding: 0 rem(22px);
-    }
-    table {
-      margin: 0 rem(32px);
-      width: auto;
-    }
-    .pre,
-    pre {
-      background: $white;
-      outline: 1px solid #e9e9e9;
-    }
-
-    code {
-      @include format-code($white);
-      outline: 1px solid #e9e9e9;
-    }
-
-    pre {
-      margin-bottom: 0;
-    }
-
-    .highlight {
-      margin: 0 rem(32px) rem(18px) rem(32px);
-    }
-
-    ul,
-    ol {
-      padding-left: rem(52px);
-      li {
-        color: $not_quite_black;
-      }
-    }
-
-    p {
-      margin-top: rem(18px);
-    }
-  }
-
-  .note .admonition-title {
-    background: #54c7ec;
-  }
-
-  .warning .admonition-title {
-    background: #e94f3b;
-  }
-
-  .tip .admonition-title {
-    background: #6bcebb;
-  }
-
-  .hint .admonition-title {
-    background: #a2cdde;
-  }
-
-  .important .admonition-title {
-    background: #5890ff;
-  }
-
-  .caution .admonition-title {
-    background: #f7923a;
-  }
-
-  .danger .admonition-title {
-    background: #db2c49;
-  }
-
-  .attention .admonition-title {
-    background: #f5a623;
-  }
-
-  .error .admonition-title {
-    background: #cc2f90;
-  }
-
-  .sphx-glr-download-link-note.admonition.note,
-  .reference.download.internal, .sphx-glr-signature {
-    display: none;
-  }
-
-  div:last-child, div.last {
-    margin-bottom: 0;
-    padding-bottom: rem(18px);
-
-    .highlight {
-      margin-bottom: 0;
-    }
-  }
-
-  p:last-child, p.last {
-    margin-bottom: 0;
-    padding-bottom: rem(18px) !important;
-  }
 }
 
 article.pytorch-article .sphx-glr-thumbcontainer {
@@ -496,14 +372,14 @@ article.pytorch-article {
       padding-left: 0;
     }
 
-    .admonition code{
-      @include format-code($white);
-      outline: 1px solid #e9e9e9;
-    }
-
-    code {
+    :not(dt) > code {
       color: $not_quite_black;
       @include format-code($light_grey);
+    }
+
+    dt > code {
+      color: $not_quite_black;
+      @include format-code($light_grey, false);
     }
 
     .viewcode-link {
@@ -625,6 +501,127 @@ article.pytorch-article {
 
   table {
     table-layout: fixed;
+  }
+}
+
+// Below defines css styles for admonitions, i.e., notes, warnings, etc.  Some
+// of these, e.g., formatting for <code/>, is supposed to over write the ones
+// defined above for entire sections, e.g, .function and .class.  So this is
+// placed later in this file, for higher precedence when both rules have same
+// specificities.
+article.pytorch-article {
+  .note,
+  .warning,
+  .tip,
+  .hint,
+  .important,
+  .caution,
+  .danger,
+  .attention,
+  .error {
+    background: $light_grey;
+    margin-top: rem(30px);
+    margin-bottom: rem(18px);
+
+    .admonition-title {
+      color: $white;
+      letter-spacing: 1px;
+      text-transform: uppercase;
+      margin-bottom: rem(18px);
+      padding: 3px 0 3px rem(22px);
+      position: relative;
+      font-size: rem(14px);
+      &:before {
+        content: "\2022";
+        position: absolute;
+        left: 9px;
+        color: $white;
+        top: 2px;
+      }
+    }
+    p:nth-child(n + 2) {
+      padding: 0 rem(22px);
+    }
+    table {
+      margin: 0 rem(32px);
+      width: auto;
+    }
+    .pre,
+    pre {
+      background: $white;
+      outline: 1px solid #e9e9e9;
+    }
+
+    :not(dt) > code {
+      @include format-code($white);
+      outline: 1px solid #e9e9e9;
+    }
+
+    pre {
+      margin-bottom: 0;
+    }
+
+    .highlight {
+      margin: 0 rem(32px) rem(18px) rem(32px);
+    }
+
+    ul,
+    ol {
+      padding-left: rem(52px);
+      li {
+        color: $not_quite_black;
+      }
+    }
+
+    p {
+      margin-top: rem(18px);
+    }
+  }
+
+  .note .admonition-title {
+    background: #54c7ec;
+  }
+
+  .warning .admonition-title {
+    background: #e94f3b;
+  }
+
+  .tip .admonition-title {
+    background: #6bcebb;
+  }
+
+  .hint .admonition-title {
+    background: #a2cdde;
+  }
+
+  .important .admonition-title {
+    background: #5890ff;
+  }
+
+  .caution .admonition-title {
+    background: #f7923a;
+  }
+
+  .danger .admonition-title {
+    background: #db2c49;
+  }
+
+  .attention .admonition-title {
+    background: #f5a623;
+  }
+
+  .error .admonition-title {
+    background: #cc2f90;
+  }
+
+  .sphx-glr-download-link-note.admonition.note,
+  .reference.download.internal, .sphx-glr-signature {
+    display: none;
+  }
+
+  .admonition > p:last-of-type {
+    margin-bottom: 0;
+    padding-bottom: rem(18px) !important;
   }
 }
 


### PR DESCRIPTION
There are two issues fixed in this PR:

1. Compatibility with sphinx 2.0. In 2.0, the `first` and `last` classes aren't set anymore. Some of our css rely on it and now fail on master doc. See https://github.com/pytorch/pytorch/issues/19318 for more details.

2. The spaces in code segments inside admonitions (e.g., notes and warnings) are still broken. E.g., for master doc, we have 
  ![Screenshot 2019-04-16 16 26 53](https://user-images.githubusercontent.com/5674597/56241679-7a845600-6064-11e9-9b79-6fc4adbfc92b.png)
    
    The outline that used to be there is also now gone. 

    The code segments are rendered as a `code` element containing a bunch of tokens, each drawn as a `pre` element. The issue is caused by that formatting, e.g., outlines, paddings and background colorings are done on the inside `pre`s rather than on the containing `code`.

    This PR fixes this by 

      + updating style of the containing `code` element to have proper background color and paddings.
      + remove styles of individual `pre`s inside .

    As a nice side effect, this PR removes the extra spacings in such code renderings because the left&right- paddings of the `pre`s are not on the containing `code`.

    The note now looks like 
    ![Screenshot 2019-04-16 16 32 46](https://user-images.githubusercontent.com/5674597/56242030-57a67180-6065-11e9-963e-18528798d34d.png)


Additionally, I fixed what is probably a typo in readme.