### PR TITLE
Fix code format in .section

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -333,6 +333,13 @@ article.pytorch-article .sphx-glr-thumbcontainer {
 }
 
 article.pytorch-article {
+  .section {
+    :not(dt) > code {
+      color: $not_quite_black;
+      @include format-code($light_grey);
+    }
+  }
+
   .function {
     dt {
       position: relative;
@@ -370,11 +377,6 @@ article.pytorch-article {
       right: 8px;
       font-size: rem(25px) !important;
       padding-left: 0;
-    }
-
-    :not(dt) > code {
-      color: $not_quite_black;
-      @include format-code($light_grey);
     }
 
     dt > code {


### PR DESCRIPTION
Fix code format not under a class/method/function. Note the last line in these two screenshots.

Current:
![image](https://user-images.githubusercontent.com/5674597/56460533-38b02400-6372-11e9-8903-59d135df1a8a.png)

After:
![image](https://user-images.githubusercontent.com/5674597/56460528-246c2700-6372-11e9-82c4-312b36ec1a37.png)
