### PR TITLE
Updated the README.md file - about .env.json file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,57 @@ Run python setup:
 python setup.py install
 ```
 
+and install the dependencies using `pip install -r docs/requirements.txt`
+
 In the root directory install the `package.json`:
 
 ```
 # node version 8.4.0
 yarn install
+
+```
+
+If you have `npm` installed then run:
+
+```
+npm install
+```
+
+- If you want to see generated documentation for `docs/demo` then create
+`.env.json` file and make it empty json file. Means `.env.json file` will
+contain
+
+```
+{}
 ```
 
 Run grunt to build the html site and enable live reloading of the demo app at `localhost:1919`:
 
 ```
 grunt
+```
+
+- If you want to specify the project folder (docs or tutorial for which
+you want to see docs generated) then you need to specify it into `.env.json`
+file:
+
+```
+{
+    "DOCS_DIR": "docs/",
+    "TUTORIALS_DIR": "path/to/tutorial/directory"
+}
+```
+
+Run grunt to build the html site for docs:
+
+```
+grunt --project=docs
+```
+
+and to build the html site for tutorial:
+
+```
+grunt --project=tutorials
 ```
 
 The resulting site is a demo.


### PR DESCRIPTION
Fixes #47 

Few lines added to guide new contributors to run it smoothly.

- `npm install` when `yarn` is not configured in system.
- Create empty `.env.json` file to use default `PROJECT_DIR`.
- Add environment variables in `.env.json` file if there is different `docs` and `tutorial` folder.
- Added lines to let people know how to use grunt options in command.