### PR TITLE
Adjust dimensions of tutorial card images

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -11229,7 +11229,7 @@ a:hover {
 #tutorial-cards-container .card.tutorials-card {
   border-radius: 0;
   border-color: #f3f4f7;
-  height: 110px;
+  height: 98px;
   margin-bottom: 1.25rem;
   margin-bottom: 1.875rem;
   overflow: scroll;
@@ -11245,20 +11245,32 @@ a:hover {
 @media (min-width: 768px) and (max-width: 1239px) {
   #tutorial-cards-container .card.tutorials-card {
     height: 200px;
-    overflow: inherit;
+    overflow: scroll;
   }
 }
 #tutorial-cards-container .card.tutorials-card .tutorials-image {
   position: absolute;
   top: 0px;
   right: 0px;
-  height: 100%;
-  width: 25%;
+  height: 96px;
+  width: 96px;
   opacity: 0.5;
 }
 #tutorial-cards-container .card.tutorials-card .tutorials-image img {
   height: 100%;
   width: 100%;
+}
+@media screen and (min-width: 768px) {
+  #tutorial-cards-container .card.tutorials-card .tutorials-image {
+    height: 100%;
+    width: 25%;
+  }
+}
+@media (min-width: 768px) and (max-width: 1239px) {
+  #tutorial-cards-container .card.tutorials-card .tutorials-image {
+    height: 100%;
+    width: 198px;
+  }
 }
 #tutorial-cards-container .card.tutorials-card .tutorials-image:before {
   content: '';
@@ -11272,10 +11284,20 @@ a:hover {
   opacity: .075;
 }
 #tutorial-cards-container .card.tutorials-card .card-title-container {
-  width: 75%;
+  width: 70%;
   display: -webkit-inline-box;
   display: -ms-inline-flexbox;
   display: inline-flex;
+}
+@media screen and (min-width: 768px) {
+  #tutorial-cards-container .card.tutorials-card .card-title-container {
+    width: 75%;
+  }
+}
+@media (min-width: 768px) and (max-width: 1239px) {
+  #tutorial-cards-container .card.tutorials-card .card-title-container {
+    width: 70%;
+  }
 }
 #tutorial-cards-container .card.tutorials-card .card-title-container h4 {
   margin-bottom: 1.125rem;
@@ -11288,7 +11310,17 @@ a:hover {
   margin-bottom: 0;
   color: #6c6c6d;
   font-weight: 400;
-  width: 75%;
+  width: 70%;
+}
+@media screen and (min-width: 768px) {
+  #tutorial-cards-container .card.tutorials-card p.card-summary, #tutorial-cards-container .card.tutorials-card p.tags {
+    width: 75%;
+  }
+}
+@media (min-width: 768px) and (max-width: 1239px) {
+  #tutorial-cards-container .card.tutorials-card p.card-summary, #tutorial-cards-container .card.tutorials-card p.tags {
+    width: 70%;
+  }
 }
 #tutorial-cards-container .card.tutorials-card p.tags {
   margin-top: 30px;

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -970,7 +970,7 @@ a:hover {
   .card.tutorials-card {
     border-radius: 0;
     border-color: $light_grey;
-    height: 110px;
+    height: 98px;
     margin-bottom: rem(20px);
     margin-bottom: rem(30px);
     overflow: scroll;
@@ -984,20 +984,31 @@ a:hover {
 
     @include small-desktop {
       height: 200px;
-      overflow: inherit;
+      overflow: scroll;
     }
 
     .tutorials-image {
       position: absolute;
       top: 0px;
       right: 0px;
-      height: 100%;
-      width: 25%;
+      height: 96px;
+      width: 96px;
       opacity: 0.5;
       img {
         height: 100%;
         width: 100%;
       }
+
+      @include desktop {
+        height: 100%;
+        width: 25%;
+      }
+
+      @include small-desktop {
+        height: 100%;
+        width: 198px;
+      }
+
       &:before {
         content: '';
         position: absolute;
@@ -1012,7 +1023,13 @@ a:hover {
     }
 
     .card-title-container {
-      width: 75%;
+      width: 70%;
+      @include desktop {
+        width: 75%;
+      }
+      @include small-desktop {
+        width: 70%;
+      }
       display: inline-flex;
       h4 {
         margin-bottom: 1.125rem;
@@ -1027,7 +1044,13 @@ a:hover {
       margin-bottom: 0;
       color: $dark_grey;
       font-weight: 400;
-      width: 75%;
+      width: 70%;
+      @include desktop {
+        width: 75%;
+      }
+      @include small-desktop {
+        width: 70%;
+      }
     }
 
     p.tags {


### PR DESCRIPTION
This PR adjusts the dimensions of the tutorial card images so that the images remain square for mobile, desktop, and tablet views. Preview: https://5eb0430a50cfcdd5f1345340--shiftlab-pytorch-tutorials.netlify.app/