### PR TITLE
Update color for `self` to meet WCAG guidelines

### DIFF
--- a/scss/shared/_syntax-highlighting.scss
+++ b/scss/shared/_syntax-highlighting.scss
@@ -146,7 +146,7 @@
   color: #008080;
 }
 .highlight .bp {
-  color: #999999;
+  color: #525252;
 }
 .highlight .nb {
   color: #0086B3;


### PR DESCRIPTION
This PR updates the color for `self` in Docs.


<img width="794" alt="Screen Shot 2020-10-19 at 5 11 02 PM" src="https://user-images.githubusercontent.com/31549535/98548765-e8582a00-2267-11eb-91f3-1b91fa44739c.png">

<img width="816" alt="Screen Shot 2020-10-19 at 5 20 49 PM" src="https://user-images.githubusercontent.com/31549535/98548796-f312bf00-2267-11eb-8682-0c51565aa9d3.png">
