### PR TITLE
Fix SyntaxError issue

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -352,3 +352,10 @@ $(document).on("click", ".page", function() {
       'slow'
     );
 });
+
+var link = $("a[href='intermediate/speech_command_recognition_with_torchaudio.html']");
+
+if (link.text() == "SyntaxError") {
+    console.log("There is an issue with the intermediate/speech_command_recognition_with_torchaudio.html menu item.");
+    link.text("Speech Command Recognition with torchaudio");
+}

--- a/pytorch_sphinx_theme/static/js/theme.js
+++ b/pytorch_sphinx_theme/static/js/theme.js
@@ -1039,4 +1039,20 @@ $("#tutorial-cards p").each(function(index, item) {
     }
 });
 
+// Jump back to top on pagination click
+
+$(document).on("click", ".page", function() {
+    $('html, body').animate(
+      {scrollTop: $("#dropdown-filter-tags").position().top},
+      'slow'
+    );
+});
+
+var link = $("a[href='intermediate/speech_command_recognition_with_torchaudio.html']");
+
+if (link.text() == "SyntaxError") {
+    console.log("There is an issue with the intermediate/speech_command_recognition_with_torchaudio.html menu item.");
+    link.text("Speech Command Recognition with torchaudio");
+}
+
 },{"jquery":"jquery"}]},{},[1,2,3,4,5,6,7,8,9,10,"pytorch-sphinx-theme"]);


### PR DESCRIPTION
<img width="348" alt="Screen Shot 2020-11-23 at 10 42 48 AM" src="https://user-images.githubusercontent.com/16585245/99982507-a60b0e80-2d78-11eb-9c67-f06b2ad110a4.png">

The tutorials menu is displaying the text "SynyaxError" for one of the tutorials. This PR replaces the text with the correct name of the tutorial.