### PR TITLE
[bug] fix bug of search.html

### DIFF
--- a/pytorch_sphinx_theme/search.html
+++ b/pytorch_sphinx_theme/search.html
@@ -10,6 +10,7 @@
 {%- extends "layout.html" %}
 {% set title = _('Search') %}
 {% set script_files = script_files + ['_static/searchtools.js'] %}
+{% set script_files = script_files + ['_static/language_data.js'] %}
 {% block footer %}
   <script type="text/javascript" src="{{ pathto('searchindex.js', 1) }}" defer></script>
   {{ super() }}


### PR DESCRIPTION
   The `search.html` in this repository is already out of date because of the Sphinx 3.4.0 update.  
   In [issue 8419](https://github.com/sphinx-doc/sphinx/issues/8419) (with [pull request 8445](https://github.com/sphinx-doc/sphinx/pull/8445)), Sphinx 3.4.0 removes the default javascript loading of `language_data.js` and put it in `search.html`.  
   Without the change of `search.html`, the searchbox will not work.
