### PR TITLE
Updated script to work with array from tutorials/docs layout file

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -264,34 +264,39 @@ if (downloadNote.length >= 1) {
 
 //This code handles the Expand/Hide toggle for the Docs/Tutorials left nav items
 
-$("#pytorch-left-menu p.caption").each(function(){
-  var collapsedSections = ['Notes'];
-  var menuName = this.innerText.replace(/[^\w\s]/gi, '').trim();
-  if (collapsedSections.includes(menuName) == true && $(this).children().not(".expand-menu")) {
-      $(this).children("span").after("<span class='expand-menu'>[ + ]</span>");
-      $(this).children("span").after("<span class='hide-menu collapse'>[ - ]</span>");
-      $(this).next("ul").hide();
-  }else{
-      $(this).children("span").after("<span class='hide-menu'>[ - ]</span>");
-      $(this).children("span").after("<span class='expand-menu collapse'>[ + ]</span>");
-  }
-  })
+$( document ).ready(function() {
+    var caption = "#pytorch-left-menu p.caption";
+    var collapseAdded = $(this).not('checked');
 
-$(".expand-menu").on("click", function() {
-  $(this).next(".hide-menu").toggle();
-  $(this).parent().next("ul").toggle();
-  toggleList(this);
+    $(caption).each(function(){
+      var menuName = this.innerText.replace(/[^\w\s]/gi, '').trim();
+      $(this).find("span").addClass('checked');
+      if (collapsedSections.includes(menuName) == true && collapseAdded) {
+        $(this.firstChild).after("<span class='expand-menu'>[ + ]</span>");
+        $(this.firstChild).after("<span class='hide-menu collapse'>[ - ]</span>");
+        $(this).next("ul").hide();
+      }else if (collapsedSections.includes(menuName) == false && collapseAdded){
+        $(this.firstChild).after("<span class='expand-menu collapse'>[ + ]</span>");
+        $(this.firstChild).after("<span class='hide-menu'>[ - ]</span>");
+      }
+    })
+
+    $(".expand-menu").on("click", function() {
+      $(this).prev(".hide-menu").toggle();
+      $(this).parent().next("ul").toggle();
+      toggleList(this);
+    });
+
+    $(".hide-menu").on("click", function() {
+      $(this).next(".expand-menu").toggle();
+      $(this).parent().next("ul").toggle();
+      toggleList(this);
+    });
+
+    function toggleList(menuCommand) {
+      $(menuCommand).toggle();
+    }
 });
-
-$(".hide-menu").on("click", function() {
-  $(this).prev(".expand-menu").toggle();
-  $(this).parent().next("ul").toggle();
-  toggleList(this);
-});
-
-function toggleList(menuCommand) {
-  $(menuCommand).toggle();
-}
 
 // Get the card link from the card's link attribute
 


### PR DESCRIPTION
This PR updates the expand/collapse script to work with the tutorial and docs layout pages. The array has been moved to those layout files to avoid potential issues of shared caption titles between the two left navs. There are two additional PR's(one for docs and one for tutorials) that will need to be merged alongside this PR.
PR for tutorials: https://github.com/pytorch/tutorials/pull/1372
PR for docs: https://github.com/pytorch/pytorch/pull/52703/
