### PR TITLE
Include build files for expand/collapse

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -267,15 +267,15 @@ if (downloadNote.length >= 1) {
 $( document ).ready(function() {
     var caption = "#pytorch-left-menu p.caption";
     var collapseAdded = $(this).not('checked');
-
     $(caption).each(function(){
+      var collapsedSections = ["Package Reference"];
       var menuName = this.innerText.replace(/[^\w\s]/gi, '').trim();
       $(this).find("span").addClass('checked');
-      if (collapsedSections.includes(menuName) == true && collapseAdded) {
+      if (collapsedSections.includes(menuName) == true && collapseAdded && sessionStorage.getItem(menuName) !== "expand" || sessionStorage.getItem(menuName) == "collapse") {
         $(this.firstChild).after("<span class='expand-menu'>[ + ]</span>");
         $(this.firstChild).after("<span class='hide-menu collapse'>[ - ]</span>");
         $(this).next("ul").hide();
-      }else if (collapsedSections.includes(menuName) == false && collapseAdded){
+      } else if (collapsedSections.includes(menuName) == false && collapseAdded || sessionStorage.getItem(menuName) == "expand") {
         $(this.firstChild).after("<span class='expand-menu collapse'>[ + ]</span>");
         $(this.firstChild).after("<span class='hide-menu'>[ - ]</span>");
       }
@@ -284,19 +284,29 @@ $( document ).ready(function() {
     $(".expand-menu").on("click", function() {
       $(this).prev(".hide-menu").toggle();
       $(this).parent().next("ul").toggle();
+      var menuName = $(this).parent().text().replace(/[^\w\s]/gi, '').trim();
+      if (sessionStorage.getItem(menuName) == "collapse") {
+        sessionStorage.removeItem(menuName);
+      }
+      sessionStorage.setItem(menuName,"expand");
       toggleList(this);
     });
 
     $(".hide-menu").on("click", function() {
       $(this).next(".expand-menu").toggle();
       $(this).parent().next("ul").toggle();
+      var menuName = $(this).parent().text().replace(/[^\w\s]/gi, '').trim();
+      if (sessionStorage.getItem(menuName) == "expand") {
+        sessionStorage.removeItem(menuName);
+      }
+      sessionStorage.setItem(menuName,"collapse");
       toggleList(this);
     });
 
     function toggleList(menuCommand) {
       $(menuCommand).toggle();
     }
-});
+  });
 
 // Get the card link from the card's link attribute
 

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -2107,6 +2107,10 @@ pre code {
   color: #6c757d;
   opacity: 1;
 }
+.form-control::-moz-placeholder {
+  color: #6c757d;
+  opacity: 1;
+}
 .form-control:-ms-input-placeholder {
   color: #6c757d;
   opacity: 1;
@@ -4553,8 +4557,10 @@ tbody.collapse.show {
 @media (min-width: 576px) {
   .card-columns {
     -webkit-column-count: 3;
+       -moz-column-count: 3;
             column-count: 3;
     -webkit-column-gap: 1.25rem;
+       -moz-column-gap: 1.25rem;
             column-gap: 1.25rem;
   }
   .card-columns .card {
@@ -5670,7 +5676,7 @@ button.close {
   -webkit-transform: translateX(0);
           transform: translateX(0);
 }
-@supports ((-webkit-transform-style: preserve-3d) or (transform-style: preserve-3d)) {
+@supports (transform-style: preserve-3d) {
   .carousel-item-next.carousel-item-left,
   .carousel-item-prev.carousel-item-right {
     -webkit-transform: translate3d(0, 0, 0);
@@ -5683,7 +5689,7 @@ button.close {
   -webkit-transform: translateX(100%);
           transform: translateX(100%);
 }
-@supports ((-webkit-transform-style: preserve-3d) or (transform-style: preserve-3d)) {
+@supports (transform-style: preserve-3d) {
   .carousel-item-next,
   .active.carousel-item-right {
     -webkit-transform: translate3d(100%, 0, 0);
@@ -5696,7 +5702,7 @@ button.close {
   -webkit-transform: translateX(-100%);
           transform: translateX(-100%);
 }
-@supports ((-webkit-transform-style: preserve-3d) or (transform-style: preserve-3d)) {
+@supports (transform-style: preserve-3d) {
   .carousel-item-prev,
   .active.carousel-item-left {
     -webkit-transform: translate3d(-100%, 0, 0);
@@ -7227,7 +7233,6 @@ button.bg-dark:focus {
 }
 
 .position-sticky {
-  position: -webkit-sticky !important;
   position: sticky !important;
 }
 
@@ -7247,9 +7252,8 @@ button.bg-dark:focus {
   z-index: 1030;
 }
 
-@supports ((position: -webkit-sticky) or (position: sticky)) {
+@supports (position: sticky) {
   .sticky-top {
-    position: -webkit-sticky;
     position: sticky;
     top: 0;
     z-index: 1020;
@@ -10552,6 +10556,9 @@ article.pytorch-article .section :not(dt) > code .pre {
   outline: 0px;
   padding: 0px;
 }
+article.pytorch-article .section:only-of-type {
+  min-height: 70vh;
+}
 article.pytorch-article .function dt, article.pytorch-article .attribute dt, article.pytorch-article .class .attribute dt, article.pytorch-article .class dt {
   position: relative;
   background: #f3f4f7;
@@ -11590,6 +11597,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
 }
 
 .pytorch-content-left {
+  min-height: 100vh;
   margin-top: 2.5rem;
   width: 100%;
 }
@@ -11703,7 +11711,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   cursor: pointer;
 }
 
-.hide-menu {
+.collapse {
   display: none;
 }
 
@@ -11731,6 +11739,9 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
 }
 
 .pytorch-left-menu-search ::-webkit-input-placeholder {
+  color: #262626;
+}
+.pytorch-left-menu-search ::-moz-placeholder {
   color: #262626;
 }
 .pytorch-left-menu-search :-ms-input-placeholder {

--- a/pytorch_sphinx_theme/static/js/theme.js
+++ b/pytorch_sphinx_theme/static/js/theme.js
@@ -959,31 +959,39 @@ if (downloadNote.length >= 1) {
 
 //This code handles the Expand/Hide toggle for the Docs/Tutorials left nav items
 
-var expandMenu = "#pytorch-left-menu p.caption";
+$( document ).ready(function() {
+    var caption = "#pytorch-left-menu p.caption";
+    var collapseAdded = $(this).not('checked');
 
-if ($(expandMenu)) {
-
-    $(expandMenu).addClass("left-nav-top-caption");
-    $("#pytorch-left-menu span.caption-text").after("<span class='expand-menu'>[ + ]</span>");
-    $("#pytorch-left-menu .expand-menu").after("<span class='hide-menu'>[ - ]</span>");
-    $(expandMenu).next("ul").hide();
+    $(caption).each(function(){
+      var menuName = this.innerText.replace(/[^\w\s]/gi, '').trim();
+      $(this).find("span").addClass('checked');
+      if (collapsedSections.includes(menuName) == true && collapseAdded) {
+        $(this.firstChild).after("<span class='expand-menu'>[ + ]</span>");
+        $(this.firstChild).after("<span class='hide-menu collapse'>[ - ]</span>");
+        $(this).next("ul").hide();
+      }else if (collapsedSections.includes(menuName) == false && collapseAdded){
+        $(this.firstChild).after("<span class='expand-menu collapse'>[ + ]</span>");
+        $(this.firstChild).after("<span class='hide-menu'>[ - ]</span>");
+      }
+    })
 
     $(".expand-menu").on("click", function() {
-        $(this).next(".hide-menu").toggle();
-        $(this).parent().next("ul").toggle();
-        toggleList(this);
+      $(this).prev(".hide-menu").toggle();
+      $(this).parent().next("ul").toggle();
+      toggleList(this);
     });
 
     $(".hide-menu").on("click", function() {
-        $(this).prev(".expand-menu").toggle();
-        $(this).parent().next("ul").toggle();
-        toggleList(this);
+      $(this).next(".expand-menu").toggle();
+      $(this).parent().next("ul").toggle();
+      toggleList(this);
     });
 
     function toggleList(menuCommand) {
-        $(menuCommand).toggle();
+      $(menuCommand).toggle();
     }
-}
+});
 
 // Get the card link from the card's link attribute
 

--- a/pytorch_sphinx_theme/static/js/theme.js
+++ b/pytorch_sphinx_theme/static/js/theme.js
@@ -962,15 +962,15 @@ if (downloadNote.length >= 1) {
 $( document ).ready(function() {
     var caption = "#pytorch-left-menu p.caption";
     var collapseAdded = $(this).not('checked');
-
     $(caption).each(function(){
+      var collapsedSections = ["Package Reference"];
       var menuName = this.innerText.replace(/[^\w\s]/gi, '').trim();
       $(this).find("span").addClass('checked');
-      if (collapsedSections.includes(menuName) == true && collapseAdded) {
+      if (collapsedSections.includes(menuName) == true && collapseAdded && sessionStorage.getItem(menuName) !== "expand" || sessionStorage.getItem(menuName) == "collapse") {
         $(this.firstChild).after("<span class='expand-menu'>[ + ]</span>");
         $(this.firstChild).after("<span class='hide-menu collapse'>[ - ]</span>");
         $(this).next("ul").hide();
-      }else if (collapsedSections.includes(menuName) == false && collapseAdded){
+      } else if (collapsedSections.includes(menuName) == false && collapseAdded || sessionStorage.getItem(menuName) == "expand") {
         $(this.firstChild).after("<span class='expand-menu collapse'>[ + ]</span>");
         $(this.firstChild).after("<span class='hide-menu'>[ - ]</span>");
       }
@@ -979,19 +979,29 @@ $( document ).ready(function() {
     $(".expand-menu").on("click", function() {
       $(this).prev(".hide-menu").toggle();
       $(this).parent().next("ul").toggle();
+      var menuName = $(this).parent().text().replace(/[^\w\s]/gi, '').trim();
+      if (sessionStorage.getItem(menuName) == "collapse") {
+        sessionStorage.removeItem(menuName);
+      }
+      sessionStorage.setItem(menuName,"expand");
       toggleList(this);
     });
 
     $(".hide-menu").on("click", function() {
       $(this).next(".expand-menu").toggle();
       $(this).parent().next("ul").toggle();
+      var menuName = $(this).parent().text().replace(/[^\w\s]/gi, '').trim();
+      if (sessionStorage.getItem(menuName) == "expand") {
+        sessionStorage.removeItem(menuName);
+      }
+      sessionStorage.setItem(menuName,"collapse");
       toggleList(this);
     });
 
     function toggleList(menuCommand) {
       $(menuCommand).toggle();
     }
-});
+  });
 
 // Get the card link from the card's link attribute
 


### PR DESCRIPTION
This PR adds the build files for Expand/Collapse

### UPDATE

This PR has been updated with the functionality to "save" the expand/collapsed state between pages/page reload while the session is active. You'll be able to see this working in the preview if you visit the session storage using the Chrome DevTools([Instructions ](https://developers.google.com/web/tools/chrome-devtools/storage/sessionstorage))

Docs Preview: https://60403da2607dd52f1108d84f--shiftlab-pytorch-docs.netlify.app/