### PR TITLE
Remove last of type min-height for article sections

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -354,9 +354,6 @@ article.pytorch-article {
       @include format-code($white);
     }
   }
-  .section:only-of-type {
-    min-height: 70vh;
-  }
 
   .function {
     dt {


### PR DESCRIPTION
This PR removes the `last-of-type` minimum height for article sections that got added with PR #92. #92 was created to fix the artifacting white space issue prevalent in the CPP Docs. This PR does not remove the minimum height to the `pytorch-left-content` as doing so will reintroduce the previous issue. 