### PR TITLE
'Doc' and 'Tutorials' menu items should have orange bullet for active state

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -110,9 +110,7 @@
             <a href="{{ theme_variables.external_urls['tutorials'] }}">Tutorials</a>
           </li>
 
-          {% assign docs = "audio, text, vision, elastic, serve, xla" | split: ", " %}
-
-          <li {%- if docs contains current[1] %} class="active docs-active"{% endif %}>
+          <li {%- if theme_pytorch_project == 'docs' %} class="active docs-active"{% endif %}>
             <div id="resourcesDropdownButton" data-toggle="resources-dropdown" class="resources-dropdown">
               <a class="resource-option with-down-orange-arrow">
                 Docs

--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -110,7 +110,9 @@
             <a href="{{ theme_variables.external_urls['tutorials'] }}">Tutorials</a>
           </li>
 
-          <li {%- if theme_pytorch_project == 'docs' %} class="active docs-active"{% endif %}>
+          {% assign docs = "audio, text, vision, elastic, serve, xla" | split: ", " %}
+
+          <li {%- if docs contains current[1] %} class="active docs-active"{% endif %}>
             <div id="resourcesDropdownButton" data-toggle="resources-dropdown" class="resources-dropdown">
               <a class="resource-option with-down-orange-arrow">
                 Docs

--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -110,7 +110,7 @@
             <a href="{{ theme_variables.external_urls['tutorials'] }}">Tutorials</a>
           </li>
 
-          <li {%- if theme_pytorch_project == 'docs' %} class="active"{% endif %}>
+          <li {%- if theme_pytorch_project == 'docs' %} class="active docs-active"{% endif %}>
             <div id="resourcesDropdownButton" data-toggle="resources-dropdown" class="resources-dropdown">
               <a class="resource-option with-down-orange-arrow">
                 Docs

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -9805,6 +9805,16 @@ pre {
 .header-holder .main-menu ul li.active a {
   color: #e44c2c;
 }
+.header-holder .main-menu ul li.docs-active:after {
+  content: "•";
+  bottom: -24px;
+  color: #e44c2c;
+  font-size: 1.375rem;
+  left: -24px;
+  position: absolute;
+  right: 0;
+  text-align: center;
+}
 .header-holder .main-menu ul li:last-of-type {
   margin-right: 0;
 }
@@ -10555,6 +10565,9 @@ article.pytorch-article .section :not(dt) > code {
 article.pytorch-article .section :not(dt) > code .pre {
   outline: 0px;
   padding: 0px;
+}
+article.pytorch-article .section:only-of-type {
+  min-height: 70vh;
 }
 article.pytorch-article .function dt, article.pytorch-article .attribute dt, article.pytorch-article .class .attribute dt, article.pytorch-article .class dt {
   position: relative;

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -2107,6 +2107,10 @@ pre code {
   color: #6c757d;
   opacity: 1;
 }
+.form-control::-moz-placeholder {
+  color: #6c757d;
+  opacity: 1;
+}
 .form-control:-ms-input-placeholder {
   color: #6c757d;
   opacity: 1;
@@ -4553,8 +4557,10 @@ tbody.collapse.show {
 @media (min-width: 576px) {
   .card-columns {
     -webkit-column-count: 3;
+       -moz-column-count: 3;
             column-count: 3;
     -webkit-column-gap: 1.25rem;
+       -moz-column-gap: 1.25rem;
             column-gap: 1.25rem;
   }
   .card-columns .card {
@@ -5670,7 +5676,7 @@ button.close {
   -webkit-transform: translateX(0);
           transform: translateX(0);
 }
-@supports ((-webkit-transform-style: preserve-3d) or (transform-style: preserve-3d)) {
+@supports (transform-style: preserve-3d) {
   .carousel-item-next.carousel-item-left,
   .carousel-item-prev.carousel-item-right {
     -webkit-transform: translate3d(0, 0, 0);
@@ -5683,7 +5689,7 @@ button.close {
   -webkit-transform: translateX(100%);
           transform: translateX(100%);
 }
-@supports ((-webkit-transform-style: preserve-3d) or (transform-style: preserve-3d)) {
+@supports (transform-style: preserve-3d) {
   .carousel-item-next,
   .active.carousel-item-right {
     -webkit-transform: translate3d(100%, 0, 0);
@@ -5696,7 +5702,7 @@ button.close {
   -webkit-transform: translateX(-100%);
           transform: translateX(-100%);
 }
-@supports ((-webkit-transform-style: preserve-3d) or (transform-style: preserve-3d)) {
+@supports (transform-style: preserve-3d) {
   .carousel-item-prev,
   .active.carousel-item-left {
     -webkit-transform: translate3d(-100%, 0, 0);
@@ -7227,7 +7233,6 @@ button.bg-dark:focus {
 }
 
 .position-sticky {
-  position: -webkit-sticky !important;
   position: sticky !important;
 }
 
@@ -7247,9 +7252,8 @@ button.bg-dark:focus {
   z-index: 1030;
 }
 
-@supports ((position: -webkit-sticky) or (position: sticky)) {
+@supports (position: sticky) {
   .sticky-top {
-    position: -webkit-sticky;
     position: sticky;
     top: 0;
     z-index: 1020;
@@ -11590,6 +11594,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
 }
 
 .pytorch-content-left {
+  min-height: 100vh;
   margin-top: 2.5rem;
   width: 100%;
 }
@@ -11703,7 +11708,7 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   cursor: pointer;
 }
 
-.hide-menu {
+.collapse {
   display: none;
 }
 
@@ -11731,6 +11736,9 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
 }
 
 .pytorch-left-menu-search ::-webkit-input-placeholder {
+  color: #262626;
+}
+.pytorch-left-menu-search ::-moz-placeholder {
   color: #262626;
 }
 .pytorch-left-menu-search :-ms-input-placeholder {
@@ -12221,9 +12229,6 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   }
 }
 
-.main-menu ul li.active:after {
-  display: none;
-}
 .main-menu ul li .resources-dropdown a {
   cursor: pointer;
 }
@@ -12272,13 +12277,12 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   border-radius: 0.25rem;
 }
 
-.resources-dropdown:hover .resources-dropdown-menu {
-  display: block;
-}
-
 .main-menu ul li .resources-dropdown-menu {
   border-radius: 0;
   padding: 0;
+}
+.main-menu ul li.active:hover .resources-dropdown-menu {
+  display: block;
 }
 
 .main-menu ul li .resources-dropdown-menu .dropdown-item {

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -10566,7 +10566,6 @@ article.pytorch-article .section :not(dt) > code .pre {
   outline: 0px;
   padding: 0px;
 }
-
 article.pytorch-article .function dt, article.pytorch-article .attribute dt, article.pytorch-article .class .attribute dt, article.pytorch-article .class dt {
   position: relative;
   background: #f3f4f7;
@@ -12286,6 +12285,10 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   background-clip: padding-box;
   border: 1px solid rgba(0, 0, 0, 0.15);
   border-radius: 0.25rem;
+}
+
+.resources-dropdown:hover .resources-dropdown-menu {
+  display: block;
 }
 
 .main-menu ul li .resources-dropdown-menu {

--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -731,11 +731,6 @@
 }
 
 .main-menu ul li {
-  &.active {
-    &:after {
-      display: none;
-    }
-  }
 
   .resources-dropdown a {
     cursor: pointer;
@@ -793,16 +788,15 @@
   border-radius: 0.25rem;
 }
 
-.resources-dropdown:hover {
-  .resources-dropdown-menu {
-    display: block;
-  }
-}
-
 .main-menu ul li {
   .resources-dropdown-menu {
     border-radius: 0;
     padding: 0;
+  }
+  &.active:hover {
+    .resources-dropdown-menu {
+      display: block;
+    }
   }
 }
 

--- a/scss/_sphinx_layout.scss
+++ b/scss/_sphinx_layout.scss
@@ -788,6 +788,12 @@
   border-radius: 0.25rem;
 }
 
+.resources-dropdown:hover {
+  .resources-dropdown-menu {
+    display: block;
+  }
+}
+
 .main-menu ul li {
   .resources-dropdown-menu {
     border-radius: 0;

--- a/scss/shared/_navigation.scss
+++ b/scss/shared/_navigation.scss
@@ -102,6 +102,17 @@
       }
     }
 
+    &.docs-active:after {
+      content: "•";
+      bottom: -24px;
+      color: $orange;
+      font-size: rem(22px);
+      left: -24px;
+      position: absolute;
+      right: 0;
+      text-align: center;
+    }
+
     &:last-of-type {
       margin-right: 0;
     }


### PR DESCRIPTION
This PR adds an orange bullet to Docs and Tutorials nav active state matching the active state for the pytorch.github.io site nav

Preview: https://605e0942b7a3ad00a3f4489f--shiftlab-pytorch-docs.netlify.app/