### PR TITLE
Add google analytics support

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -77,12 +77,14 @@
 
   {%- block extrahead %}
   <!-- Google Analytics -->
-  <script>
-    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-    ga('create', '{{ theme_analytics_id }}', 'auto');
-    ga('send', 'pageview');
-  </script>
-  <script async src='https://www.google-analytics.com/analytics.js'></script>
+  {% if theme_analytics_id %}
+    <script>
+      window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+      ga('create', '{{ theme_analytics_id }}', 'auto');
+      ga('send', 'pageview');
+    </script>
+    <script async src='https://www.google-analytics.com/analytics.js'></script>
+  {% endif %}
   <!-- End Google Analytics -->
   {% endblock %}
 

--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -74,7 +74,20 @@
     <link rel="prev" title="{{ prev.title|striptags|e }}" href="{{ prev.link|e }}" />
     {%- endif %}
   {%- endblock %}
-  {%- block extrahead %} {% endblock %}
+
+  {%- block extrahead %}
+  <script type="text/javascript">
+    var _gaq = _gaq || [];
+    _gaq.push(['_setAccount', '{{ theme_analytics_id }}']);
+    _gaq.push(['_trackPageview']);
+
+    (function() {
+      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+    })();
+  </script>
+  {% endblock %}
 
   {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
   <script src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>

--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -76,17 +76,14 @@
   {%- endblock %}
 
   {%- block extrahead %}
-  <script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', '{{ theme_analytics_id }}']);
-    _gaq.push(['_trackPageview']);
-
-    (function() {
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-    })();
+  <!-- Google Analytics -->
+  <script>
+    window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+    ga('create', '{{ theme_analytics_id }}', 'auto');
+    ga('send', 'pageview');
   </script>
+  <script async src='https://www.google-analytics.com/analytics.js'></script>
+  <!-- End Google Analytics -->
   {% endblock %}
 
   {# Keep modernizr in head - http://modernizr.com/docs/#installing #}


### PR DESCRIPTION
Closes https://github.com/pytorch/pytorch_sphinx_theme/issues/109

This PR adds GA support to the theme via the `analytics_id` config option, which was documented but ignored: https://github.com/pytorch/pytorch_sphinx_theme/blob/8eff7df04b7fe5bc5173daa5031b94e062d5fc64/docs/configuring.rst .

The solution is inspired from https://www.ericholscher.com/blog/2009/apr/5/adding-google-analytics-sphinx-docs/ and uses a more modern script as recommended in https://developers.google.com/analytics/devguides/collection/analyticsjs#alternative_async_tag