### PR TITLE
Use correct capitalization of GitHub

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -190,7 +190,7 @@
           </li>
 
           <li>
-            <a href="{{ theme_variables.external_urls['github'] }}">Github</a>
+            <a href="{{ theme_variables.external_urls['github'] }}">GitHub</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
This PR changes the capitalization from _Github_ to _GitHub_ in the page navigation menu.