### PR TITLE
Remove 6px horizontal padding in span.pre

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -10408,7 +10408,7 @@ h1 {
 span.pre {
   color: #6c6c6d;
   background-color: #f3f4f7;
-  padding: 2px 6px;
+  padding: 2px 0px;
 }
 
 pre {

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -203,7 +203,7 @@ h1 {
 span.pre {
   color: $content_text_color;
   background-color: $light_grey;
-  padding: 2px 6px;
+  padding: 2px 0px;
 }
 
 pre {


### PR DESCRIPTION
Sphinx 3.x puts class signatures inside `<span class="pre">` tags,
and this 6px horizontal padding was making it look bad.
Seen screenshots below.

I'm not sure why this padding was added in the first place, so it's possible this change makes something worse, but from a few minutes of poking around I don't see anything that looks bad.

Part of addressing general sphinx 3 support: #115.

Before:
![conv3d-before](https://user-images.githubusercontent.com/421339/127712584-51bc14a1-b0eb-4758-a570-9d4cdbb85d3e.jpg)

After:
![conv3d-after](https://user-images.githubusercontent.com/421339/127712600-c7ed09ae-4e0f-4b5f-91de-a595aa7aa998.jpg)
