### PR TITLE
Css tweaks

### DIFF
--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -207,7 +207,6 @@ span.pre {
 }
 
 pre {
-  background-color: $light_grey;
   padding: rem(22px);
 }
 
@@ -564,11 +563,6 @@ article.pytorch-article {
     table {
       margin: 0 rem(32px);
       width: auto;
-    }
-    .pre,
-    pre {
-      background: $white;
-      outline: 1px solid #e9e9e9;
     }
 
     :not(dt) > code {

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -540,6 +540,7 @@ article.pytorch-article {
     background: $light_grey;
     margin-top: rem(30px);
     margin-bottom: rem(18px);
+    padding-bottom: 1px; // needed for nested directives (code inside note)
 
     .admonition-title {
       color: $white;


### PR DESCRIPTION
Fix issue #129: add a small margin around admonitions for nested directives

Fix issue #130: do not set background color for spans within admonitions (like double-backticked "pre" spans).