### PR TITLE
make absolute positioning more specific

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -10590,7 +10590,6 @@ article.pytorch-article .function dt em, article.pytorch-article .attribute dt e
   font-size: 87.5%;
 }
 article.pytorch-article .function dt a, article.pytorch-article .attribute dt a, article.pytorch-article .class .attribute dt a, article.pytorch-article .class dt a {
-  position: absolute;
   right: 30px;
   padding-right: 0;
   top: 50%;
@@ -10616,6 +10615,8 @@ article.pytorch-article .function dt > code, article.pytorch-article .attribute 
   box-decoration-break: clone;
 }
 article.pytorch-article .function .viewcode-link, article.pytorch-article .attribute .viewcode-link, article.pytorch-article .class .viewcode-link {
+  padding-left: 0.6rem;
+  position: absolute;
   font-size: 0.875rem;
   color: #979797;
   letter-spacing: 0;

--- a/scss/_sphinx_base.scss
+++ b/scss/_sphinx_base.scss
@@ -373,7 +373,6 @@ article.pytorch-article {
       }
 
       a {
-        position: absolute;
         right: 30px;
         padding-right: 0;
         top: 50%;
@@ -399,6 +398,8 @@ article.pytorch-article {
     }
 
     .viewcode-link {
+      padding-left: rem(10px);
+      position: absolute;
       font-size: rem(14px);
       color: #979797;
       letter-spacing: 0;


### PR DESCRIPTION
Fixes #115. The typing annotations have a link to the documentation of the entity, and the theme formatted links `<a>` with `position: absolute` in order to properly position the `[SOURCE]` link. This PR moves the more-specific rendering to the more-specific class.
Note how the `int` attributes are blue, since they are links

![Screenshot from 2021-08-20 15-06-12](https://user-images.githubusercontent.com/823911/130230678-fbff54f7-549e-4786-a862-5207122c3225.png)

Compare this to the image copied from #115 where only removing the positioning moves the `[SOURCE]` to be hidden
![from issue 115](https://user-images.githubusercontent.com/855818/120712210-5d9e7d00-c48e-11eb-9f93-a51721e42526.png)


@brianjo