### PR TITLE
Footer: provide link to correct Sphinx theme

### DIFF
--- a/pytorch_sphinx_theme/footer.html
+++ b/pytorch_sphinx_theme/footer.html
@@ -64,7 +64,7 @@
   {%- if show_sphinx %}
     {% trans %}
       <div>
-        Built with <a href="http://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/rtfd/sphinx_rtd_theme">theme</a> provided by <a href="https://readthedocs.org">Read the Docs</a>.
+        Built with <a href="https://sphinx-doc.org/">Sphinx</a> using a <a href="https://github.com/pytorch/pytorch_sphinx_theme">theme</a> provided by <a href="https://pytorch.org/">PyTorch</a>.
       </div>
     {% endtrans %}
   {%- endif %}


### PR DESCRIPTION
The footer claims that we are using the RtD theme when we are actually using our own theme.

@calebrob6