### PR TITLE
Hide placeholder from left menu search on focus

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -11751,6 +11751,22 @@ article.pytorch-article .tutorials-callout-container .btn.callout-button a {
   color: #262626;
 }
 
+.pytorch-left-menu-search :focus::-webkit-input-placeholder {
+  color: transparent;
+}
+.pytorch-left-menu-search :focus::-moz-placeholder {
+  color: transparent;
+}
+.pytorch-left-menu-search :focus:-ms-input-placeholder {
+  color: transparent;
+}
+.pytorch-left-menu-search :focus::-ms-input-placeholder {
+  color: transparent;
+}
+.pytorch-left-menu-search :focus::placeholder {
+  color: transparent;
+}
+
 .pytorch-left-menu-search input[type=text] {
   border-radius: 0;
   padding: 0.5rem 0.75rem;


### PR DESCRIPTION
Related to https://github.com/pytorch/pytorch/issues/11968. It seems that the bullet alignment was fixed in https://github.com/pytorch/pytorch_sphinx_theme/commit/374627a5cac62ee9f9cb2762c63d1ecd37f154e7, so this PR fixes the placeholder that should be hiding on focus.

cc @ezyang 