### PR TITLE
Replace footer mailchimp form with social links and fix nav

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -124,7 +124,9 @@
             <a href="{{ theme_variables.external_urls['tutorials'] }}">Tutorials</a>
           </li>
 
-          <li {%- if theme_pytorch_project == 'docs' %} class="active docs-active"{% endif %}>
+          {% assign docs = "xla, serve, elastic" | split: ", " %}
+
+          <li {%- if theme_pytorch_project == 'docs' || docs contains current[1] %} class="active docs-active"{% endif %}>
             <div id="resourcesDropdownButton" data-toggle="resources-dropdown" class="resources-dropdown">
               <a class="resource-option with-down-orange-arrow">
                 Docs
@@ -427,46 +429,24 @@
 
         <div class="footer-links-col follow-us-col">
           <ul>
-            <li class="list-title">Stay Connected</li>
-            <li>
-              <div id="mc_embed_signup">
-                <form
-                  action="https://twitter.us14.list-manage.com/subscribe/post?u=75419c71fe0a935e53dfa4a3f&id=91d0dccd39"
-                  method="post"
-                  id="mc-embedded-subscribe-form"
-                  name="mc-embedded-subscribe-form"
-                  class="email-subscribe-form validate"
-                  target="_blank"
-                  novalidate>
-                  <div id="mc_embed_signup_scroll" class="email-subscribe-form-fields-wrapper">
-                    <div class="mc-field-group">
-                      <label for="mce-EMAIL" style="display:none;">Email Address</label>
-                      <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL" placeholder="Email Address">
-                    </div>
-
-                    <div id="mce-responses" class="clear">
-                      <div class="response" id="mce-error-response" style="display:none"></div>
-                      <div class="response" id="mce-success-response" style="display:none"></div>
-                    </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-
-                    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_75419c71fe0a935e53dfa4a3f_91d0dccd39" tabindex="-1" value=""></div>
-
-                    <div class="clear">
-                      <input type="submit" value="" name="subscribe" id="mc-embedded-subscribe" class="button email-subscribe-button">
-                    </div>
-                  </div>
-                </form>
-              </div>
-
-            </li>
+            <li class="list-title"><p>Stay up to date</p></li>
+            <li><a href="https://www.facebook.com/pytorch" target="_blank">Facebook</a></li>
+            <li><a href="https://twitter.com/pytorch" target="_blank">Twitter</a></li>
+            <li><a href="https://www.youtube.com/pytorch" target="_blank">YouTube</a></li>
+            <li><a href="https://www.linkedin.com/company/pytorch/" target="_blank">LinkedIn</a></li>
           </ul>
-
-          <div class="footer-social-icons">
-            <a href="{{ theme_variables.external_urls['facebook'] }}" target="_blank" class="facebook"></a>
-            <a href="{{ theme_variables.external_urls['twitter'] }}" target="_blank" class="twitter"></a>
-            <a href="{{ theme_variables.external_urls['youtube'] }}" target="_blank" class="youtube"></a>
-          </div>
         </div>
+
+        <div class="footer-links-col">
+          <ul>
+            <li class="list-title"><p>PyTorch Podcasts</p></li>
+            <li><a href="{{ site.external_urls.spotify }}" target="_blank">Spotify</a></li>
+            <li><a href="{{ site.external_urls.apple }}" target="_blank">Apple</a></li>
+            <li><a href="{{ site.external_urls.google }}" target="_blank">Google</a></li>
+            <li><a href="{{ site.external_urls.amazon }}" target="_blank">Amazon</a></li>
+          </ul>
+        </div>
+      </div>
       </div>
     </div>
   </footer>


### PR DESCRIPTION
This PR removes mailchimp form in the footer and replaces it with social links.

Also fixes the active state for some Docs pages

Preview: https://shiftlab-pytorch-cpp-docs.netlify.app/