### PR TITLE
replace TorchElastic link with TorchX

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -146,12 +146,12 @@
                   <span class="dropdown-title">torchvision</span>
                   <p></p>
                 </a>
-                <a class="doc-dropdown-option nav-dropdown-item" href="{{ theme_variables.external_urls['elastic'] }}">
-                  <span class="dropdown-title">TorchElastic</span>
-                  <p></p>
-                </a>
                 <a class="doc-dropdown-option nav-dropdown-item" href="{{ theme_variables.external_urls['serve'] }}">
                   <span class="dropdown-title">TorchServe</span>
+                  <p></p>
+                </a>
+                <a class="doc-dropdown-option nav-dropdown-item" href="{{ theme_variables.external_urls['torchx'] }}">
+                  <span class="dropdown-title">TorchX</span>
                   <p></p>
                 </a>
                 <a class="doc-dropdown-option nav-dropdown-item" href="{{ theme_variables.external_urls['xla'] }}">
@@ -536,11 +536,11 @@
             </li>
 
             <li>
-              <a href="{{ theme_variables.external_urls['elastic'] }}">TorchElastic</a>
+              <a href="{{ theme_variables.external_urls['serve'] }}">TorchServe</a>
             </li>
 
             <li>
-              <a href="{{ theme_variables.external_urls['serve'] }}">TorchServe</a>
+              <a href="{{ theme_variables.external_urls['torchx'] }}">TorchX</a>
             </li>
 
             <li>

--- a/pytorch_sphinx_theme/theme_variables.jinja
+++ b/pytorch_sphinx_theme/theme_variables.jinja
@@ -26,6 +26,7 @@
   'text': 'https://pytorch.org/text/stable/index.html',
   'vision': 'https://pytorch.org/vision/stable/index.html',
   'elastic': 'https://pytorch.org/elastic/',
+  'torchx': 'https://pytorch.org/torchx/',
   'serve': 'https://pytorch.org/serve/',
   'xla': 'https://pytorch.org/xla'
 }


### PR DESCRIPTION
This removes TorchElastic from the Docs dropdown and replaces it with TorchX.

TorchElastic docs page is just a stub now after it's been merged into two different projects. https://pytorch.org/elastic/latest/

TorchX is a new PyTorch project https://pytorch.org/torchx/latest/

Test Plan:

```
make html
python -m http.server 8000
```

![2021-11-02-154627_1121x653_scrot](https://user-images.githubusercontent.com/909104/139962605-3a69fa48-9d37-448f-8f63-3408c06e46f1.png)
![Screen Shot 2021-11-02 at 15 45 42](https://user-images.githubusercontent.com/909104/139962610-33ee6492-ac54-48b1-880c-0fe478f2fc20.png)
