### PR TITLE
Remove `text-transform: uppercase` on case-sensitive titles

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -8,7 +8,7 @@
 :root {
   --blue: #007bff;
   --indigo: #6610f2;
-  --purple: #6f42c1;
+  --purple: #6f42c1;text-transform: uppercase
   --pink: #e83e8c;
   --red: #dc3545;
   --orange: #fd7e14;
@@ -10440,7 +10440,6 @@ h1 {
   font-size: 2rem;
   letter-spacing: 1.78px;
   line-height: 2.5rem;
-  text-transform: uppercase;
   margin: 1.375rem 0;
 }
 

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -8,7 +8,7 @@
 :root {
   --blue: #007bff;
   --indigo: #6610f2;
-  --purple: #6f42c1;text-transform: uppercase
+  --purple: #6f42c1;
   --pink: #e83e8c;
   --red: #dc3545;
   --orange: #fd7e14;


### PR DESCRIPTION
It's confusing enough that PyTorch provides `torch.Tensor` and `torch.tensor`.

It makes it even worse that CSS implies that this is case-insensitive and shows the page titles identically:

https://pytorch.org/docs/stable/tensors.html
https://pytorch.org/docs/stable/generated/torch.tensor.html#torch.tensor

`text-transform` should generally be avoided - it causes lots of usability issues.