### PR TITLE
Fix API docs formatting

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -1,4 +1,4 @@
-euufbktejugblttnknjdcnhfitbd/charset "UTF-8";
+@charset "UTF-8";
 /*!
  * Bootstrap v4.0.0 (https://getbootstrap.com)
  * Copyright 2011-2018 The Bootstrap Authors
@@ -10617,7 +10617,7 @@ article.pytorch-article .section :not(dt) > code .pre {
 article.pytorch-article .function dt, article.pytorch-article .attribute dt, article.pytorch-article .class .attribute dt, article.pytorch-article .class dt {
   position: relative;
   background: #f3f4f7;
-  padding: 0.8rem;
+  padding: 0.5rem;
   border-left: 3px solid #ee4c2c;
   word-wrap: break-word;
   padding-right: 100px;
@@ -10626,24 +10626,18 @@ article.pytorch-article .function dt, article.pytorch-article .attribute dt, art
 article.pytorch-article .class dt.field-odd, article.pytorch-article .class dt.field-even,
 article.pytorch-article .function dt.field-odd, article.pytorch-article .function dt.field-even,
 article.pytorch-article .attribute dt.field-odd, article.pytorch-article .attribute dt.field-even,
-article.pytorch-article .class .attribute dt.field-odd,article.pytorch-article .class .attribute dt.field-even
+article.pytorch-article .class .attribute dt.field-odd,article.pytorch-article .class .attribute dt.field-even,
+article.pytorch-article .class .method dt.field-odd, article.pytorch-article .class .staticmethod dt.field-odd,
+article.pytorch-article .class .method dt.field-even, article.pytorch-article .class .staticmethod dt.field-even
 {
   background: none;
   padding-right: -20px;
   border-top: none;
-  padding-left: 0.0rem;
-  padding-top: 0.0rem;
-  padding-bottom: 0.0rem;
-  font-weight: 700;
-}
-
-article.pytorch-article .class .method dt.field-odd, article.pytorch-article .class .staticmethod dt.field-odd,
-article.pytorch-article .class .method dt.field-even, article.pytorch-article .class .staticmethod dt.field-even {
   border-left: none;
-  font-weight: 700;
   padding-left: 0.0rem;
   padding-top: 0.0rem;
   padding-bottom: 0.0rem;
+  font-weight: 700;
 }
 
 article.pytorch-article .function dt.sig {
@@ -10711,7 +10705,7 @@ article.pytorch-article .function .viewcode-link, article.pytorch-article .attri
 article.pytorch-article .function dd, article.pytorch-article .attribute dd, article.pytorch-article .class .attribute dd, article.pytorch-article .class dd {
   padding-left: 3.75rem;
 }
-article.pytorch-article .function dd p, article.pytorch-article .attribute dd p, article.pytorch-article .class .attribute dd p, article.pytorch-article .class dd p{
+article.pytorch-article .function dd p, article.pytorch-article .attribute dd p, article.pytorch-article .class .attribute dd p, article.pytorch-article .class dd p {
   color: #262626;
 }
 article.pytorch-article .function table tbody tr th.field-name, article.pytorch-article .attribute table tbody tr th.field-name, article.pytorch-article .class table tbody tr th.field-name {
@@ -10782,7 +10776,7 @@ article.pytorch-article .class dl dt em.property {
 }
 
 article.pytorch-article .class .method dt,
-article.pytorch-article .class .staticmethod {
+article.pytorch-article .class .staticmethod dt {
   border-left: 3px solid #ee4c2c;
   border-top: none;
 }

--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -1,4 +1,4 @@
-@charset "UTF-8";
+euufbktejugblttnknjdcnhfitbd/charset "UTF-8";
 /*!
  * Bootstrap v4.0.0 (https://getbootstrap.com)
  * Copyright 2011-2018 The Bootstrap Authors
@@ -10617,11 +10617,56 @@ article.pytorch-article .section :not(dt) > code .pre {
 article.pytorch-article .function dt, article.pytorch-article .attribute dt, article.pytorch-article .class .attribute dt, article.pytorch-article .class dt {
   position: relative;
   background: #f3f4f7;
-  padding: 0.5rem;
+  padding: 0.8rem;
   border-left: 3px solid #ee4c2c;
   word-wrap: break-word;
   padding-right: 100px;
 }
+
+article.pytorch-article .class dt.field-odd, article.pytorch-article .class dt.field-even,
+article.pytorch-article .function dt.field-odd, article.pytorch-article .function dt.field-even,
+article.pytorch-article .attribute dt.field-odd, article.pytorch-article .attribute dt.field-even,
+article.pytorch-article .class .attribute dt.field-odd,article.pytorch-article .class .attribute dt.field-even
+{
+  background: none;
+  padding-right: -20px;
+  border-top: none;
+  padding-left: 0.0rem;
+  padding-top: 0.0rem;
+  padding-bottom: 0.0rem;
+  font-weight: 700;
+}
+
+article.pytorch-article .class .method dt.field-odd, article.pytorch-article .class .staticmethod dt.field-odd,
+article.pytorch-article .class .method dt.field-even, article.pytorch-article .class .staticmethod dt.field-even {
+  border-left: none;
+  font-weight: 700;
+  padding-left: 0.0rem;
+  padding-top: 0.0rem;
+  padding-bottom: 0.0rem;
+}
+
+article.pytorch-article .function dt.sig {
+  position: relative;
+  background: #f3f4f7;
+  padding: 0.8rem;
+  border-left: 3px solid #ee4c2c;
+  word-wrap: break-word;
+  padding-right: 100px;
+  font-weight: 500;
+}
+
+article.pytorch-article .function dt {
+  background: #ffffff;
+  padding-right: -20px;
+  border-left: none;
+  border-top: none;
+  padding-left: 0.0rem;
+  padding-top: 0.0rem;
+  padding-bottom: 0.0rem;
+  font-weight: 700;
+}
+
 article.pytorch-article .function dt em.property, article.pytorch-article .attribute dt em.property, article.pytorch-article .class dt em.property {
   font-family: inherit;
 }
@@ -10666,7 +10711,7 @@ article.pytorch-article .function .viewcode-link, article.pytorch-article .attri
 article.pytorch-article .function dd, article.pytorch-article .attribute dd, article.pytorch-article .class .attribute dd, article.pytorch-article .class dd {
   padding-left: 3.75rem;
 }
-article.pytorch-article .function dd p, article.pytorch-article .attribute dd p, article.pytorch-article .class .attribute dd p, article.pytorch-article .class dd p {
+article.pytorch-article .function dd p, article.pytorch-article .attribute dd p, article.pytorch-article .class .attribute dd p, article.pytorch-article .class dd p{
   color: #262626;
 }
 article.pytorch-article .function table tbody tr th.field-name, article.pytorch-article .attribute table tbody tr th.field-name, article.pytorch-article .class table tbody tr th.field-name {
@@ -10735,11 +10780,13 @@ article.pytorch-article .class dl dt em.property {
   left: 0;
   padding-right: 0;
 }
+
 article.pytorch-article .class .method dt,
-article.pytorch-article .class .staticmethod dt {
+article.pytorch-article .class .staticmethod {
   border-left: 3px solid #ee4c2c;
   border-top: none;
 }
+
 article.pytorch-article .class .method dt,
 article.pytorch-article .class .staticmethod dt {
   padding-left: 0.5rem;


### PR DESCRIPTION
Fix #178 
Test plan:
- Checkout this PR
- Run the grunt build locally as described in the README: https://github.com/pytorch/pytorch_sphinx_theme#local-development
- Open the api.html page to view the formatting which should look like this:
<img width="859" alt="Screenshot 2023-05-03 at 4 03 34 PM" src="https://user-images.githubusercontent.com/5317992/236497924-4c462d2c-b5e6-42bb-9dab-087d18998847.png">
