### PR TITLE
update jquery dependency

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,6 +23,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.viewcode',
     'sphinxcontrib.httpdomain',
+    'sphinxcontrib.jquery',
 ]
 
 # Do not warn about external images (status badges in README.rst)

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,3 +1,4 @@
+// jQuery is included via the sphinxcontrib-jquery extension that we depend on
 var jQuery = (typeof(window) != 'undefined') ? window.jQuery : require('jquery');
 
 // Sphinx theme nav state

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         "Topic :: Software Development :: Documentation"
     ],
     install_requires=[
-       'sphinx'
+       'sphinx',
+       'sphinxcontrib-jquery',
     ]
 )


### PR DESCRIPTION
The new `sphinx>=6.0` will not add jquery automatically and will throw exception. It's necessary to use `sphinxcontrib-jquery` to use jquery.

For details, see https://github.com/readthedocs/sphinx_rtd_theme/pull/1385 for more details.