### PR TITLE
remove deprecated `style` variable

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -41,8 +41,6 @@
 
   {% endif %}
 
-  <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
-  <!-- <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" /> -->
   {%- for css in css_files %}
     {%- if css|attr("rel") %}
   <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />


### PR DESCRIPTION
`style` variable is deprecated in `sphinx 7.0.0`. However, in current `pytorch_sphinx_theme`, we are still using it.

https://github.com/pytorch/pytorch_sphinx_theme/blob/a1dbd5cfa0a69ee023d0c0acc167fb0cbd8619f6/pytorch_sphinx_theme/layout.html#L43-L45


Following is the solution from `sphinx-rtd-theme`:  
https://github.com/readthedocs/sphinx_rtd_theme/blob/03a86b803cf7cf281748ef94345ba7c35953952a/sphinx_rtd_theme/layout.html#L26-L30

They add an if condition for compatibility with very old `sphinx<4.0`. I think we can just remove those codes.


-------------------------------

https://www.sphinx-doc.org/en/master/changes.html

<img width="933" alt="image" src="https://github.com/readthedocs/sphinx_rtd_theme/assets/13214530/d93f7ba7-fc2a-4ee8-ab84-2371867e4f3c">