### PR TITLE
Disable CCI Job

### DIFF
--- a/.circleci/config.yml.in
+++ b/.circleci/config.yml.in
@@ -31,9 +31,3 @@ jobs:
       - run: git add .
       - run: git commit -m "Deploying theme build via CircleCI"
       - run: git push -q git@github.com:pytorch/pytorch_sphinx_theme.git master
-
-workflows:
-  version: 2
-  commit-and-build:
-      jobs:
-        - build


### PR DESCRIPTION
Since the CCI Job for this repo has been broken for nearly 2 years, we are disabling the job so it no longer runs. Repo Owners should fix the job and migrate to GHA when time permits.