### PR TITLE
Restore the gtag JavaScript function to re-enable metrics

### DIFF
--- a/pytorch_sphinx_theme/layout.html
+++ b/pytorch_sphinx_theme/layout.html
@@ -81,7 +81,9 @@
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
     'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','{{ theme_analytics_id }}');</script>
+    })(window,document,'script','dataLayer','{{ theme_analytics_id }}');
+    function gtag(){dataLayer.push(arguments);}
+    </script>
     <!-- End Google Tag Manager -->
   {% endblock %}
 


### PR DESCRIPTION
The associated issue is in the pytorch/tutorials repository:

Issue #2696 · [BUG]
No longer collecting star-rating data...since transition to GA4 https://github.com/pytorch/tutorials/issues/2696

The gtag function is used by metrics such as star-rating in the tutorials repository (which leverages pytorch_sphinx_theme).

The definition for the gtag function was deleted in the transition to Google Analytics 4 (GA4) in PR#182, which in-turn broke our metrics.

This commit restores the definition of the function to re-enable these metrics.