### PR TITLE
Remove uppercase in H1s

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -10440,7 +10440,6 @@ h1 {
   font-size: 2rem;
   letter-spacing: 1.78px;
   line-height: 2.5rem;
-  text-transform: uppercase;
   margin: 1.375rem 0;
 }
 
@@ -10494,7 +10493,9 @@ article.pytorch-article ol ul,
 article.pytorch-article ol ol {
   margin: 0;
 }
-article.pytorch-article h1,
+article.pytorch-article h1 {
+  font-weight: 600;
+}
 article.pytorch-article h2,
 article.pytorch-article h3,
 article.pytorch-article h4,


### PR DESCRIPTION
Change the heading 1 style to not use all uppercase and  add weight: 600 for h1. 
Before:
<img width="779" alt="before_uppercase" src="https://github.com/pytorch/pytorch_sphinx_theme/assets/5317992/b6a4d719-7e73-45ff-9901-9e54264ead1e">
After:
<img width="720" alt="after_normal" src="https://github.com/pytorch/pytorch_sphinx_theme/assets/5317992/1a6a68c2-e20f-4e60-bdb8-9c8912b68c5a">
