### PR TITLE
Tables: enable horizontal scrolling

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -215,6 +215,8 @@ svg:not(:root) {
 
 table {
   border-collapse: collapse;
+  display: block;
+  overflow-x: auto;
 }
 
 caption {
@@ -9986,7 +9988,7 @@ pre {
 
 .site-footer .privacy-policy-links {
     background: #000000;
-    display: flex; 
+    display: flex;
     padding-top: 1rem;
     padding-right: 1rem;
     display: inline-flex;


### PR DESCRIPTION
Fixes #191 

Tables that are too wide to display correctly can now be scrolled horizontally