### PR TITLE
Fix various issues in the theme

### DIFF
--- a/pytorch_sphinx_theme/static/css/theme.css
+++ b/pytorch_sphinx_theme/static/css/theme.css
@@ -10237,7 +10237,6 @@ article.pytorch-article dl dt,
 article.pytorch-article dl dd,
 article.pytorch-article blockquote {
   font-size: 1rem;
-  line-height: 1.375rem;
   color: #262626;
   letter-spacing: 0.01px;
   font-weight: 500;
@@ -10526,6 +10525,7 @@ article.pytorch-article ol ol {
 }
 article.pytorch-article h1 {
   font-weight: 600;
+  word-wrap: break-word;
 }
 article.pytorch-article h2,
 article.pytorch-article h3,
@@ -10687,10 +10687,16 @@ article.pytorch-article .function dt {
   padding-right: -20px;
   border-left: none;
   border-top: none;
-  padding-left: 0.0rem;
+  padding-left: 0.2rem;
   padding-top: 0.0rem;
   padding-bottom: 0.0rem;
   font-weight: 700;
+}
+
+article.pytorch-article .class dl.py.property dt.sig {
+  border-left: 3px solid #ee4c2c;
+  border-top: none;
+  padding-left: 0.2rem;
 }
 
 article.pytorch-article .function dt em.property, article.pytorch-article .attribute dt em.property, article.pytorch-article .class dt em.property {


### PR DESCRIPTION
* Fixes the issue with the Python decorators being indented in the HTML:
<img width="759" alt="fix1" src="https://github.com/pytorch/pytorch_sphinx_theme/assets/5317992/0378a901-5322-4c42-b528-f1f3d2323a5f">

* Fixes https://github.com/pytorch/pytorch/issues/123336 by resetting the line-height in `article.pytorch-article p`:
<img width="825" alt="fix2" src="https://github.com/pytorch/pytorch_sphinx_theme/assets/5317992/b3852035-205c-4d92-8a95-0e4062e9ce73">

 
* Fixes https://github.com/pytorch/pytorch/issues/125919 by adding `word-wrap: break-word;` to `article.pytorch-article h1` 
<img width="1026" alt="fix3" src="https://github.com/pytorch/pytorch_sphinx_theme/assets/5317992/06f441b6-efee-4dca-96d9-da36b6a130c9">