### PR TITLE
Add pyproject.toml to handle deprecation of legacy editable installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__
 dist/
 *.egg-info/
 scss/vendor/*
+*.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools >= 64", "sphinx", "sphinxcontrib-httpdomain"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 from setuptools import setup
-from io import open
 import os
 import sys
 
-base_path = os.path.dirname(__file__)
-sys.path.insert(0, base_path)
+REPO_ROOT = os.path.dirname(__file__)
+sys.path.insert(0, REPO_ROOT)
 from pytorch_sphinx_theme import __version__
 sys.path.pop(0)
+
 setup(
     name = 'pytorch_sphinx_theme',
     version =__version__,

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,12 @@
 from setuptools import setup
 from io import open
-from pytorch_sphinx_theme import __version__
+import os
+import sys
 
+base_path = os.path.dirname(__file__)
+sys.path.insert(0, base_path)
+from pytorch_sphinx_theme import __version__
+sys.path.pop(0)
 setup(
     name = 'pytorch_sphinx_theme',
     version =__version__,


### PR DESCRIPTION
Followed https://ichard26.github.io/blog/2024/08/whats-new-in-pip-24.2/#legacy-editable-installs-are-deprecated to add a pyproject.toml

Tried `pip install -e .` and received no warning.  

I don't know if this changes anything else under the hood