### PR TITLE
Change how ipynb download link is found

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -250,10 +250,19 @@ if (downloadNote.length >= 1) {
     var tutorialUrlArray = $("#tutorial-type").text().split('/');
         tutorialUrlArray[0] = tutorialUrlArray[0] + "_source"
 
-    var githubLink = "https://github.com/pytorch/tutorials/blob/master/" + tutorialUrlArray.join("/") + ".py",
-        notebookLink = $(".reference.download")[1].href,
-        notebookDownloadPath = notebookLink.split('_downloads')[1],
-        colabLink = "https://colab.research.google.com/github/pytorch/tutorials/blob/gh-pages/_downloads" + notebookDownloadPath;
+    var githubLink = "https://github.com/pytorch/tutorials/blob/master/" + tutorialUrlArray.join("/") + ".py";
+    var notebookLink = "";
+    // some versions of sphinx gallery have different orders of the download
+    // links so we need to check if the link ends with .ipynb to find the
+    // correct one
+    for (var i = 0; i < $(".reference.download").length; i++) {
+        notebookLink = $(".reference.download")[i].href;
+        if (notebookLink.endsWith(".ipynb")) {
+            break;
+        }
+    }
+    var notebookDownloadPath = notebookLink.split('_downloads')[1];
+    var colabLink = "https://colab.research.google.com/github/pytorch/tutorials/blob/gh-pages/_downloads" + notebookDownloadPath;
 
     $("#google-colab-link").wrap("<a href=" + colabLink + " data-behavior='call-to-action-event' data-response='Run in Google Colab' target='_blank'/>");
     $("#download-notebook-link").wrap("<a href=" + notebookLink + " data-behavior='call-to-action-event' data-response='Download Notebook'/>");
@@ -428,4 +437,3 @@ $(window).scroll(function () {
     }
   });
 });
-

--- a/pytorch_sphinx_theme/static/js/theme.js
+++ b/pytorch_sphinx_theme/static/js/theme.js
@@ -945,10 +945,19 @@ if (downloadNote.length >= 1) {
     var tutorialUrlArray = $("#tutorial-type").text().split('/');
         tutorialUrlArray[0] = tutorialUrlArray[0] + "_source"
 
-    var githubLink = "https://github.com/pytorch/tutorials/blob/master/" + tutorialUrlArray.join("/") + ".py",
-        notebookLink = $(".reference.download")[1].href,
-        notebookDownloadPath = notebookLink.split('_downloads')[1],
-        colabLink = "https://colab.research.google.com/github/pytorch/tutorials/blob/gh-pages/_downloads" + notebookDownloadPath;
+    var githubLink = "https://github.com/pytorch/tutorials/blob/master/" + tutorialUrlArray.join("/") + ".py";
+    var notebookLink = "";
+    // some versions of sphinx gallery have different orders of the download
+    // links so we need to check if the link ends with .ipynb to find the
+    // correct one
+    for (var i = 0; i < $(".reference.download").length; i++) {
+        notebookLink = $(".reference.download")[i].href;
+        if (notebookLink.endsWith(".ipynb")) {
+            break;
+        }
+    }
+    var notebookDownloadPath = notebookLink.split('_downloads')[1];
+    var colabLink = "https://colab.research.google.com/github/pytorch/tutorials/blob/gh-pages/_downloads" + notebookDownloadPath;
 
     $("#google-colab-link").wrap("<a href=" + colabLink + " data-behavior='call-to-action-event' data-response='Run in Google Colab' target='_blank'/>");
     $("#download-notebook-link").wrap("<a href=" + notebookLink + " data-behavior='call-to-action-event' data-response='Download Notebook'/>");


### PR DESCRIPTION
sphinx gallery 0.11.1 puts it 2nd, but 0.17.1 puts it first, so the wrong link gets used

Made change in js/theme.js then ran `grunt build` and a bunch of stuff got generated, no idea if that's correct, so I ended up not committing the `grunt build` changes and just made the change manually in the static folder