### PR TITLE
templates: Turn off google search by default

### DIFF
--- a/pytorch_sphinx_theme2/templates/search-field-custom.html
+++ b/pytorch_sphinx_theme2/templates/search-field-custom.html
@@ -60,7 +60,11 @@
 
     // Check if the URL contains /stable/ or /tutorials/
     const currentUrl = window.location.href;
-    const shouldDefaultToGoogle = currentUrl.includes('/stable/') || currentUrl.includes('/tutorials/');
+    // TODO: We've had reports that the google programmable search is returning stale documentation,
+    //       Simple reproduction is to turn google search on and search for multinomial which will
+    //       result in returning 1.8.1 documentation.
+    //       We should turn this back on when we resolve that bug.
+    const shouldDefaultToGoogle = false;
     const savedPreference = localStorage.getItem('searchPreference');
 
     // Set initial state


### PR DESCRIPTION
TODO: We've had reports that the google programmable search is returning stale documentation,
Simple reproduction is to turn google search on and search for multinomial which will
result in returning 1.8.1 documentation.
We should turn this back on when we resolve that bug.

<img width="985" height="625" alt="Screenshot 2025-08-29 at 9 43 53 AM" src="https://github.com/user-attachments/assets/f131b755-de93-43e0-a735-0b68f6ec161d" />

btw it's a bit concerning to me that this branch powers most of our docs, isn't searchable by regular github search. Can we just merge this branch into main?