### PR TITLE
Fix json-ld

### DIFF
--- a/pytorch_sphinx_theme2/templates/layout.html
+++ b/pytorch_sphinx_theme2/templates/layout.html
@@ -191,8 +191,9 @@
    <script type="application/ld+json">
       {
          "@context": "https://schema.org",
-         "@type": "Article",
-         "headline": "{{ title|striptags }}",
+         "@type": "TechArticle",
+         "name": {{ title|striptags|trim|tojson }},
+         "headline": {{ title|striptags|trim|tojson }},
          "description": "PyTorch Documentation. Explore PyTorch, an open-source machine learning library that accelerates the path from research prototyping to production deployment. Discover tutorials, API references, and guides to help you build and deploy deep learning models efficiently.",
          "url": "{{ canonical_url|default((url_root if url_root is defined else '/') + pagename + '.html', true) }}",
          "author": {
@@ -205,9 +206,8 @@
            "@type": "WebPage",
            "@id": "{{ canonical_url|default((url_root if url_root is defined else '/') + pagename + '.html', true) }}"
          },
-        "datePublished": "{{ doc_created|default('') }}{% if doc_created %}T00:00:00Z{% endif %}",
-         "dateModified": "{{ doc_updated|default('') }}{% if doc_updated %}T00:00:00Z{% endif %}",
-         "articleBody": "{{ (body|striptags|truncate(3000, true))|replace('\\', '\\\\')|replace('"', '\\"')|e }}"
+         "datePublished": "{{ doc_created|default('') }}{% if doc_created %}T00:00:00Z{% endif %}",
+         "dateModified": "{{ doc_updated|default('') }}{% if doc_updated %}T00:00:00Z{% endif %}"
        }
    </script>
 {% endblock %}


### PR DESCRIPTION
- Change Article to TechArticle for better SEO
- Removed articleBody as it causes error in structure due to LaTeX formatting. 
- Updated the "headline" field to correctly capture headline. Previous implementation caused invalid JSON when page titles contained special characters or code syntax
- Added name field which is required for this type of schema.