### PR TITLE
Fix regex pattern for includenodoc to parse raw docstring

### DIFF
--- a/pytorch_sphinx_theme2/custom_directives.py
+++ b/pytorch_sphinx_theme2/custom_directives.py
@@ -12,9 +12,11 @@ except NameError:
 
 try:
     import sphinx_gallery
+
     HAS_SPHINX_GALLERY = True
 except ImportError:
     HAS_SPHINX_GALLERY = False
+
 
 class IncludeDirective(Directive):
     """Include source file without docstring at the top of file.
@@ -36,7 +38,7 @@ class IncludeDirective(Directive):
     has_content = False
     add_index = False
 
-    docstring_pattern = r'"""(?P<docstring>(?:.|[\r\n])*?)"""\n'
+    docstring_pattern = r'r?"""(?P<docstring>(?:.|[\r\n])*?)"""\n'
     docstring_regex = re.compile(docstring_pattern)
 
     def run(self):
@@ -92,7 +94,9 @@ class GalleryItemDirective(Directive):
             if "intro" in self.options:
                 intro = self.options["intro"][:195] + "..."
             else:
-                block_parser = sphinx_gallery.gen_rst.BlockParser(abs_fname, {"filetype_parsers": {}})
+                block_parser = sphinx_gallery.gen_rst.BlockParser(
+                    abs_fname, {"filetype_parsers": {}}
+                )
                 _, blocks, _ = block_parser.split_code_and_text_blocks(abs_fname)
                 intro, _ = sphinx_gallery.gen_rst.extract_intro_and_title(
                     abs_fname, blocks[0][1]

--- a/pytorch_sphinx_theme2/custom_directives.py
+++ b/pytorch_sphinx_theme2/custom_directives.py
@@ -12,11 +12,9 @@ except NameError:
 
 try:
     import sphinx_gallery
-
     HAS_SPHINX_GALLERY = True
 except ImportError:
     HAS_SPHINX_GALLERY = False
-
 
 class IncludeDirective(Directive):
     """Include source file without docstring at the top of file.
@@ -94,9 +92,7 @@ class GalleryItemDirective(Directive):
             if "intro" in self.options:
                 intro = self.options["intro"][:195] + "..."
             else:
-                block_parser = sphinx_gallery.gen_rst.BlockParser(
-                    abs_fname, {"filetype_parsers": {}}
-                )
+                block_parser = sphinx_gallery.gen_rst.BlockParser(abs_fname, {"filetype_parsers": {}})
                 _, blocks, _ = block_parser.split_code_and_text_blocks(abs_fname)
                 intro, _ = sphinx_gallery.gen_rst.extract_intro_and_title(
                     abs_fname, blocks[0][1]


### PR DESCRIPTION
This PR solves the problem in pytorch/tutorials#3619. In the "Learning PyTorch with Examples" tutorial, the autograd code block started with `rimport`, where it should be `import`. This happened because the custom `includenodoc` directive didn't include the `r` as part of a raw docstring like

```py
r"""
PyTorch: Tensors and autograd
...
"""
```