### PR TITLE
Add tippy.js support into the theme 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 import pytorch_sphinx_theme2
+
 # import torch  # Temporarily commented out for testing
 
 html_theme = "pytorch_sphinx_theme2"
@@ -31,6 +32,13 @@ extensions = [
     "sphinx_gallery.gen_gallery",
     "sphinx_design",
     "myst_nb",
+    "sphinx_tippy",
+]
+
+# MyST parser configuration for markdown files
+myst_enable_extensions = [
+    "colon_fence",
+    "deflist",
 ]
 
 print(
@@ -93,6 +101,18 @@ master_doc = "index"
 project = "PyTorch Sphinx Theme2"
 copyright = "PyTorch"
 
+# sphinx-tippy configuration for glossary tooltips
+tippy_props = {
+    "placement": "auto-start",
+    "maxWidth": 500,
+    "interactive": True,  # Allow clicking links inside tooltips
+    "theme": "material",
+}
+
+# Skip all URLs except glossary term links (glossary.html#term-*)
+tippy_skip_urls = (r"^(?!.*glossary\.html#term-).*$",)
+tippy_enable_mathjax = True
+
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
@@ -116,9 +136,9 @@ html_context = {
     "feedback_url": "https://github.com/pytorch/pytorch_sphinx_theme",
     "github_url": "https://github.com",
     "github_user": "pytorch",
-    "github_repo": "tutorials",     # Changed to tutorials for tutorial buttons
-    "github_version": "main",       # Changed to main branch for tutorials
-    "colab_branch": "gh-pages",     # New variable for Colab branch
+    "github_repo": "tutorials",  # Changed to tutorials for tutorial buttons
+    "github_version": "main",  # Changed to main branch for tutorials
+    "colab_branch": "gh-pages",  # New variable for Colab branch
     "doc_path": "docs",
     "extra_project_links": theme_variables.get("extra_project_links", []),
     "date_info": {
@@ -136,7 +156,12 @@ html_context = {
 html_static_path = ["_static"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = [
+    "_build",
+    "build",
+    "jupyter_execute",
+    "**.ipynb_checkpoints",
+]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None
@@ -158,7 +183,12 @@ pygments_style = "default"
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 
-intersphinx_mapping = {"rtd": ("https://docs.readthedocs.io/en/latest/", None)}
+intersphinx_mapping = {
+    "rtd": ("https://docs.readthedocs.io/en/latest/", None),
+    "python": ("https://docs.python.org/3/", None),
+    "torch": ("https://docs.pytorch.org/docs/stable/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+}
 pytorch_sphinx_theme2.custom_directives.HAS_SPHINX_GALLERY = True
 
 # -- Options for HTML output ---------------------------------------------------
@@ -224,10 +254,10 @@ html_theme_options = {
     # },
     # "canonical_url": "https://pytorch.org/docs/stable/",
     "canonical_url": "http://localhost:8000",
-    #"pytorch_project": "tutorials",
-    #"show_lf_header": False,
-    #"show_lf_footer": False,
-  }
+    # "pytorch_project": "tutorials",
+    # "show_lf_header": False,
+    # "show_lf_footer": False,
+}
 
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,51 @@
+(glossary)=
+# PyTorch Glossary
+
+This glossary provides definitions for terms commonly used in PyTorch documentation.
+
+```{glossary}
+ATen
+    Short for "A Tensor Library". The foundational tensor and mathematical operation library on which all else is built.
+
+Compound Kernel
+    Opposed to {term}`Device Kernel`s, Compound kernels are usually device-agnostic and belong to {term}`Compound Operation`s.
+
+Compound Operation
+    A Compound Operation is composed of other {term}`Operation`s. Its {term}`Kernel` is usually device-agnostic. Normally it doesn't have its own derivative functions defined. Instead, AutoGrad automatically computes its derivative based on operations it uses.
+
+Composite Operation
+    Same as {term}`Compound Operation`.
+
+Custom Operation
+    An {term}`Operation` defined by users, usually a {term}`Compound Operation`. For example, this [tutorial](https://pytorch.org/docs/stable/notes/extending.html) details how to create Custom Operations.
+
+Device Kernel
+    Device-specific {term}`Kernel` of a {term}`Leaf Operation`.
+
+JIT
+    Just-In-Time Compilation.
+
+Kernel
+    Implementation of a PyTorch {term}`Operation`, specifying what should be done when an operation executes.
+
+Leaf Operation
+    An {term}`Operation` that's considered a basic operation, as opposed to a {term}`Compound Operation`. Leaf Operation always has dispatch functions defined, usually has a derivative function defined as well.
+
+Native Operation
+    An {term}`Operation` that comes natively with PyTorch ATen, for example `aten::matmul`.
+
+Non-Leaf Operation
+    Same as {term}`Compound Operation`.
+
+Operation
+    A unit of work. For example, the work of matrix multiplication is an operation called `aten::matmul`.
+
+Scripting
+    Using `torch.jit.script` on a function to inspect source code and compile it as {term}`TorchScript` code.
+
+TorchScript
+    Deprecated. An interface to the TorchScript {term}`JIT` compiler and interpreter.
+
+Tracing
+    Using `torch.jit.trace` on a function to get an executable that can be optimized using just-in-time compilation.
+```

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,3 +31,8 @@ Welcome to PyTorch Sphinx Theme 2 Docs
     :caption: This is an incredibly long caption for a long menu
 
     demo/long
+
+Indices and tables
+------------------
+
+* :ref:`Glossary <glossary>`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,6 @@ docutils=>0.19
 sphinx==7.2.6
 sphinx-gallery==0.11.1
 pydata_sphinx_theme==0.15.4
+myst-nb>=1.0.0
+sphinx-tippy>=0.4.3
+sphinx-design

--- a/docs/test-glossary.md
+++ b/docs/test-glossary.md
@@ -1,0 +1,76 @@
+(torch.compiler_ir)=
+
+# IRs
+
+PyTorch 2.0 offers two set of IRs for backends to interface with: Core {term}`ATen` IR and Prims IR.
+
+## Core ATen IR
+
+Core {term}`aten<ATen>` ops is the core subset of {term}`aten<ATen>` operators that can be used to compose other operators.
+Core {term}`aten<ATen>` IR is fully functional, and there is no `inplace` or `_out` variants in this opset.
+In contrast to Prims IR, core {term}`aten<ATen>` ops reuses the existing {term}`aten<ATen>` ops in "native_functions.yaml",
+and it doesn't further decompose ops into explicit type promotion and broadcasting ops.
+This opset is designed to serve as the functional IR to interface with backends.
+
+```{warning}
+  This opset is still under active development, more ops will be added in the future.
+```
+
+## Prims IR
+
+Prims IR is a set of primitive operators that can be used to compose other operators.
+Prims IR is a lower level opset than core aten IR, and it further decomposes ops into explicit
+type promotion and broadcasting ops: prims.convert_element_type and prims.broadcast_in_dim.
+This opset is designed to interface with compiler backends.
+
+```{warning}
+  This opset is still under active development, more ops will be added in the future.
+```
+
+## Glossary Terms Demo
+
+This section demonstrates tooltips for various glossary terms. Hover over the highlighted terms to see their definitions.
+
+### Operations
+
+An {term}`Operation` is a unit of work in PyTorch. There are different types of operations:
+
+- **{term}`Native Operation`**: Operations that come natively with PyTorch ATen
+- **{term}`Custom Operation`**: Operations defined by users, usually a {term}`Compound Operation`
+- **{term}`Leaf Operation`**: Basic operations that always have dispatch functions defined
+- **{term}`Compound Operation`**: Operations composed of other operations (also known as {term}`Composite Operation` or {term}`Non-Leaf Operation`)
+
+### Kernels
+
+A {term}`Kernel` is the implementation of a PyTorch operation. There are two main types:
+
+- **{term}`Device Kernel`**: Device-specific kernel of a {term}`Leaf Operation`
+- **{term}`Compound Kernel`**: Device-agnostic kernels that belong to {term}`Compound Operations<Compound Operation>`
+
+### JIT Compilation
+
+PyTorch supports {term}`JIT` (Just-In-Time) compilation through {term}`TorchScript`. There are two main approaches:
+
+1. **{term}`Tracing`**: Using `torch.jit.trace` on a function to get an executable that can be optimized
+2. **{term}`Scripting`**: Using `torch.jit.script` to inspect source code and compile it as {term}`TorchScript` code
+
+### Summary Table
+
+| Term | Type | Description |
+|------|------|-------------|
+| {term}`ATen` | Library | Foundational tensor library |
+| {term}`Operation` | Concept | Unit of work |
+| {term}`Kernel` | Implementation | What happens when an operation executes |
+| {term}`JIT` | Technique | Just-In-Time Compilation |
+| {term}`TorchScript` | Interface | JIT compiler and interpreter |
+
+## Intersphinx References
+
+Note: Intersphinx tooltips only work with documentation hosted on Read the Docs that has the embed API enabled.
+Most external documentation sites (docs.python.org, docs.pytorch.org, numpy.org) do not support this feature.
+
+The following are standard intersphinx links (clickable but without tooltips):
+
+- {py:class}`torch:torch.Tensor` - The main tensor class
+- {py:func}`torch:torch.zeros` - Create a tensor of zeros
+- {py:class}`python:list` - Python's built-in list type

--- a/pytorch_sphinx_theme2/static/css/theme.css
+++ b/pytorch_sphinx_theme2/static/css/theme.css
@@ -3337,6 +3337,95 @@ span.highlighted {
   background-color: #ffe4e4;
 }
 
+.tippy-box {
+  background-color: var(--pst-color-background);
+  color: var(--pst-color-text-base);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  border-radius: 6px;
+  border: 1px solid var(--pst-color-border);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+  max-width: 450px;
+}
+
+.tippy-box .tippy-content {
+  padding: 12px 16px;
+}
+
+.tippy-box .tippy-arrow {
+  color: var(--pst-color-background);
+}
+
+.tippy-box .tippy-arrow::before {
+  border-top-color: var(--pst-color-background);
+  border-bottom-color: var(--pst-color-background);
+}
+
+.tippy-box a {
+  color: var(--pst-color-primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+.tippy-box a:hover {
+  color: var(--pst-color-secondary);
+  text-decoration: underline;
+}
+
+.tippy-box code {
+  background-color: var(--pst-color-surface);
+  color: var(--pst-color-text-base);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.8125rem;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.tippy-box strong,
+.tippy-box .term-title,
+.tippy-box dt {
+  color: var(--pst-color-primary);
+  font-weight: 600;
+}
+
+.tippy-box p {
+  margin: 0 0 0.5rem 0;
+  font-weight: normal;
+}
+.tippy-box p:last-child {
+  margin-bottom: 0;
+}
+
+.tippy-box dd {
+  font-weight: normal;
+}
+.tippy-box dd strong {
+  font-weight: normal;
+}
+
+.tippy-box dl {
+  margin: 0;
+}
+.tippy-box dl dt {
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+.tippy-box dl dd {
+  margin: 0 0 0.5rem 0;
+}
+.tippy-box dl dd:last-child {
+  margin-bottom: 0;
+}
+
+.tippy-box ul,
+.tippy-box ol {
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
+}
+.tippy-box ul li,
+.tippy-box ol li {
+  margin-bottom: 0.25rem;
+}
+
 /*!
  * Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)

--- a/pytorch_sphinx_theme2/static/scss/_tippy.scss
+++ b/pytorch_sphinx_theme2/static/scss/_tippy.scss
@@ -1,0 +1,110 @@
+// Sphinx-tippy tooltip styles
+// Uses PyData Sphinx Theme's built-in CSS variables for automatic light/dark mode support
+
+@use 'variables' as *;
+
+// Tippy box base styles - using PyData theme variables
+.tippy-box {
+  background-color: var(--pst-color-background);
+  color: var(--pst-color-text-base);
+  font-size: 0.875rem;
+  line-height: 1.6;
+  border-radius: 6px;
+  border: 1px solid var(--pst-color-border);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+  max-width: 450px;
+}
+
+// Tippy content padding
+.tippy-box .tippy-content {
+  padding: 12px 16px;
+}
+
+// Tippy arrow
+.tippy-box .tippy-arrow {
+  color: var(--pst-color-background);
+}
+
+// Arrow border
+.tippy-box .tippy-arrow::before {
+  border-top-color: var(--pst-color-background);
+  border-bottom-color: var(--pst-color-background);
+}
+
+// Links inside tooltips
+.tippy-box a {
+  color: var(--pst-color-primary);
+  text-decoration: none;
+  font-weight: 500;
+
+  &:hover {
+    color: var(--pst-color-secondary);
+    text-decoration: underline;
+  }
+}
+
+// Code inside tooltips
+.tippy-box code {
+  background-color: var(--pst-color-surface);
+  color: var(--pst-color-text-base);
+  padding: 2px 6px;
+  border-radius: 3px;
+  font-size: 0.8125rem;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+}
+
+// Headers/strong text inside tooltips (glossary term names)
+.tippy-box strong,
+.tippy-box .term-title,
+.tippy-box dt {
+  color: var(--pst-color-primary);
+  font-weight: 600;
+}
+
+// Paragraphs inside tooltips
+.tippy-box p {
+  margin: 0 0 0.5rem 0;
+  font-weight: normal;  // Reset bold text inside paragraphs
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+// Reset bold styling for content inside dd (definition description)
+.tippy-box dd {
+  font-weight: normal;
+
+  strong {
+    font-weight: normal;  // Don't bold text that was bolded in source
+  }
+}
+
+// Definition lists inside tooltips (for glossary terms)
+.tippy-box dl {
+  margin: 0;
+
+  dt {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+  }
+
+  dd {
+    margin: 0 0 0.5rem 0;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+// Lists inside tooltips
+.tippy-box ul,
+.tippy-box ol {
+  margin: 0.5rem 0;
+  padding-left: 1.25rem;
+
+  li {
+    margin-bottom: 0.25rem;
+  }
+}

--- a/pytorch_sphinx_theme2/static/scss/main.scss
+++ b/pytorch_sphinx_theme2/static/scss/main.scss
@@ -13,6 +13,7 @@
 @use 'runllm';
 @use 'sphinx_design';
 @use 'search';
+@use 'tippy';
 
 // Import FontAwesome
 @use "@fortawesome/fontawesome-free/scss/fontawesome";


### PR DESCRIPTION
Adds support for glossary tooltips in the PyTorch Sphinx Theme using the `sphinx-tippy` extension.

* Added a new `docs/glossary.md` file containing definitions for common PyTorch terms for testing.
* Created `docs/test-glossary.md` for testing.
* Updated `docs/index.rst` to include a reference to the glossary in the indices and tables section for testing
* Enabled the `sphinx_tippy` extension and added configuration for tooltip appearance and interactivity in `docs/conf.py`, along with `intersphinx_mapping` for external documentation references. 
* Implemented a `setup_tippy_defaults` function in `pytorch_sphinx_theme2/__init__.py` to set sensible default tooltip behaviors, such as anchor selection and skip rules, and registered it with the Sphinx app.
* Added extensive SCSS for `.tippy-box` to ensure tooltips match the PyData Sphinx Theme’s light/dark modes, with custom styles for links, code, lists, and glossary formatting
* Compiled the theme.css with `npx grunt docs`
* For now, {term} links in the glossary itself won't work but if this gets merged, they will: https://github.com/sphinx-extensions2/sphinx-tippy/pull/33. 