### PR TITLE
Upload doc preview to S3

### DIFF
--- a/.github/workflows/build-theme.yml
+++ b/.github/workflows/build-theme.yml
@@ -49,3 +49,23 @@ jobs:
           path: docs/_build/html/
       # Doc previews are handled automatically by Netlify
       # See netlify.toml for configuration
+
+  doc-preview:
+    runs-on: linux.2xlarge
+    needs: build-docs
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: documentation
+          path: docs/_build/html
+
+      - name: Upload docs preview
+        uses: seemethere/upload-artifact-s3@v5
+        with:
+          retention-days: 14
+          s3-bucket: doc-previews
+          if-no-files-found: error
+          path: docs/_build/html
+          s3-prefix: pytorch_sphinx_theme/${{ github.event.pull_request.number }}


### PR DESCRIPTION
We can simply use our AWS self-hosted runners which already have the permission to upload to S3 `gha-artifacts` bucket

@svekars This is an example, feel free to close the PR if it's not needed

### Testing

https://github.com/pytorch/pytorch_sphinx_theme/actions/runs/21195497256/job/60970491633?pr=222