### PR TITLE
Update cookie banner to Meta, link to open source

### DIFF
--- a/pytorch_sphinx_theme/cookie_banner.html
+++ b/pytorch_sphinx_theme/cookie_banner.html
@@ -1,6 +1,6 @@
 <div class="cookie-banner-wrapper">
   <div class="container">
-    <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://www.facebook.com/policies/cookies/">Cookies Policy</a>.</p>
+    <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Meta’s Cookies Policy applies. Learn more, including about available controls: <a href="https://opensource.fb.com/legal/cookie-policy">Cookies Policy</a>.</p>
     <img class="close-button" src="{{ pathto('_static/images/pytorch-x.svg', 1) }}">
   </div>
 </div>


### PR DESCRIPTION
When we use this banner on Meta-specific sites, we should use the correct company name and link to the open source cookie policy as we do with other projects.