### PR TITLE
Bump theme to v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to pytorch_sphinx_theme2 are documented here.
 
+## v0.4.6
+
+### Improvements
+
+- **LLM Navigation Guide (llms.txt) Improvements** (PR #237) — Enhanced the `llms.txt` generator with several fixes:
+  - Now enabled by default — generates `llms.txt` automatically unless disabled or a custom file is provided
+  - Spec-compliant format with H1 title, quote block description, H2 sections, and proper title format
+  - Added optional `llm_deduplicate_titles` theme option to disambiguate duplicate titles (e.g., "GRU" → "GRU (torch.nn.GRU)")
+  - Generic fallback uses project name for description if `llm_description` is not set
+
+### Bug Fixes
+
+- **Google Search Fix** (PR #236) — Fixed issues with the Google custom search bar styling and responsive behavior
+
+---
+
 ## v0.4.5
 
 ### New Features

--- a/pytorch_sphinx_theme2/__init__.py
+++ b/pytorch_sphinx_theme2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 import json
 import os
@@ -694,7 +694,7 @@ def setup(app):
         )
 
     return {
-        "version": "0.4.5",
+        "version": "0.4.6",
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="svekars@meta.com",
     url="https://github.com/pytorch/pytorch_sphinx_theme",
     license="MIT",
-    version="0.4.5",
+    version="0.4.6",
     install_requires=[
         "pydata-sphinx-theme==0.15.4",
         "sphinx>=5.3.0,<=7.2.6",


### PR DESCRIPTION
Bumps pytorch_sphinx_theme2 to version 0.4.6

# Improvements

- LLM Navigation Guide (llms.txt) Enhancements (PR #237)
	- Now enabled by default — generates llms.txt automatically unless explicitly disabled or a custom file is provided
	- Spec-compliant format — includes H1 title, quote block description, H2 sections, and proper title format per the [llms.txt standard](https://llmstxt.org/)
	- Added llm_deduplicate_titles theme option to disambiguate duplicate titles (e.g., "GRU" → "GRU (torch.nn.GRU)")
	- Generic fallback uses project name for description if llm_description is not set

# Bug Fixes
Google Search Fix (PR #236) — Fixed issues with the Google custom search bar styling and responsive behavior