### PR TITLE
Add HTML-to-markdown generation for llms.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ scss/vendor/*
 *.pyc
 docs/auto_examples/*
 docs/sg_execution_times.rst
+.claude/

--- a/configuration-reference.md
+++ b/configuration-reference.md
@@ -340,6 +340,47 @@ html_theme_options = {
 }
 ```
 
+#### `llm_generate_md`
+- **Type:** String (`"true"` or `"false"`)
+- **Default:** `"true"` (enabled by default)
+- **Description:** When enabled, generates a clean `.md` (Markdown) file alongside each `.html` page in the build output, and links to `.md` files in `llms.txt` instead of `.html` files. Also generates `llms-full.txt`, a single file concatenating all page content for easy LLM ingestion (per the [llms.txt spec](https://llmstxt.org/)).
+
+The generated `.md` files strip all navigation, sidebars, scripts, and theme-injected metadata (e.g., date info), producing clean, readable content suitable for LLMs. Unicode smart quotes and other typographic characters are normalized to ASCII equivalents for maximum compatibility.
+
+**Generated files:**
+- `*.md` — one per HTML page, alongside the `.html` files
+- `llms.txt` — page index with links to `.md` files
+- `llms-full.txt` — all page content concatenated into a single file
+
+```python
+html_theme_options = {
+    "llm_generate_md": "true",  # Enabled by default
+}
+```
+
+To disable markdown generation (links in `llms.txt` will point to `.html` files):
+
+```python
+html_theme_options = {
+    "llm_generate_md": "false",
+}
+```
+
+#### `llm_deduplicate_titles`
+- **Type:** String (`"true"` or `"false"`)
+- **Default:** `"false"`
+- **Description:** When enabled, adds disambiguating suffixes to duplicate page titles in `llms.txt`. Useful for projects with auto-generated API docs where multiple pages share the same title.
+
+For example, if two pages are both titled "GRU", they become:
+- `GRU (torch.nn.GRU)`
+- `GRU (torch.nn.GRUCell)`
+
+```python
+html_theme_options = {
+    "llm_deduplicate_titles": "true",
+}
+```
+
 #### Source-Root Convention
 
 If no `llm_custom_file` is specified, the theme automatically checks for a file named `llms.txt` in the Sphinx source root directory (the same directory as `conf.py`). If found, it is used as-is instead of auto-generating one. This allows a zero-config override — just drop an `llms.txt` file next to `conf.py`.

--- a/pytorch_sphinx_theme2/__init__.py
+++ b/pytorch_sphinx_theme2/__init__.py
@@ -4,13 +4,18 @@ import json
 import os
 import posixpath
 import re
-import shutil
 import subprocess
 from pathlib import Path
 from uuid import uuid4
 
 from . import custom_directives
 from .custom_directives import HAS_SPHINX_GALLERY
+from .llm_generation import (
+    _generate_llms_txt,
+    _generate_md_files,
+    _generate_llms_full_txt,
+    _html_to_markdown,
+)
 
 # Optional import for tippy glossary support
 try:
@@ -158,205 +163,6 @@ def add_date_info_to_page(app, pagename, templatename, context, doctree):
 
         except Exception as e:
             print(f"Error getting dates for {full_source_path}: {e}")
-
-
-# =============================================================================
-# LLM Navigation Guide (llms.txt) support
-# =============================================================================
-
-
-def _build_llms_url(domain, base_path, version, relative_path=""):
-    """Build a full URL for llms.txt links.
-
-    Args:
-        domain: The documentation domain (e.g., "docs.pytorch.org")
-        base_path: The base path after domain (e.g., "docs/", "vision/")
-        version: The documentation version (e.g., "stable", "2.0.0")
-        relative_path: The relative path to the page (e.g., "index.html")
-
-    Returns:
-        Full URL like "https://docs.pytorch.org/docs/stable/index.html"
-    """
-    # Ensure domain doesn't have trailing slash
-    domain = domain.rstrip("/")
-
-    # Ensure base_path has proper format (no leading slash, has trailing slash if non-empty)
-    base_path = base_path.strip("/")
-    if base_path:
-        base_path = base_path + "/"
-
-    # Ensure version doesn't have slashes
-    version = version.strip("/")
-
-    # Ensure relative_path doesn't have leading slash
-    relative_path = relative_path.lstrip("/")
-
-    # Build URL
-    if relative_path:
-        return f"https://{domain}/{base_path}{version}/{relative_path}"
-    else:
-        return f"https://{domain}/{base_path}{version}/"
-
-
-def _generate_llms_txt(app, exception):
-    """Dynamically generate llms.txt during documentation build.
-
-    The file is resolved in this order:
-
-    1. **Explicit disable** — ``llm_disabled = "true"`` skips generation entirely.
-    2. **Custom file** — ``llm_custom_file`` theme option pointing to a file
-       relative to the Sphinx source directory.
-    3. **Convention** — A file named ``llms.txt`` in the Sphinx source root.
-    4. **Auto-generation** — A simple page listing following the llms.txt spec,
-       with URLs resolved as:
-       a. ``llm_domain`` + ``llm_base_path`` theme options → fully constructed URLs
-       b. Sphinx ``html_baseurl`` config → baseurl + relative path
-       c. Relative URLs as a last resort
-
-    Enabled by default. Set ``llm_disabled = "true"`` to disable.
-    """
-    if exception is not None:
-        return  # Don't generate if build failed
-
-    if app.builder.name != "html":
-        return
-
-    # Enabled by default; opt-out with llm_disabled = "true"
-    theme_options = app.config.html_theme_options or {}
-    if str(theme_options.get("llm_disabled", "false")).lower() == "true":
-        return
-
-    dest_path = Path(app.outdir) / "llms.txt"
-
-    # --- 1. Explicit option: llm_custom_file ---
-    custom_file = theme_options.get("llm_custom_file", "").strip()
-    if custom_file:
-        custom_path = Path(app.srcdir) / custom_file
-        if custom_path.is_file():
-            shutil.copy2(custom_path, dest_path)
-            print(f"Copied custom llms.txt from: {custom_path}")
-            return
-        else:
-            print(
-                f"Warning: llm_custom_file '{custom_file}' not found at "
-                f"{custom_path}, falling back to auto-generation"
-            )
-
-    # --- 2. Convention: llms.txt in the source root ---
-    source_llms = Path(app.srcdir) / "llms.txt"
-    if source_llms.is_file():
-        shutil.copy2(source_llms, dest_path)
-        print(f"Using project-provided llms.txt from: {source_llms}")
-        return
-
-    # --- 3. Auto-generation ---
-    # Get configuration
-    project = app.config.project or "Documentation"
-    version = app.config.version or "latest"
-    domain = theme_options.get("llm_domain", "").strip()
-    base_path = theme_options.get("llm_base_path", "").strip()
-
-    # Resolve the base URL for links:
-    # Priority: llm_domain > html_baseurl > relative
-    html_baseurl = getattr(app.config, "html_baseurl", None) or ""
-    html_baseurl = html_baseurl.strip().rstrip("/")
-
-    def make_url(relative_path):
-        if domain:
-            return _build_llms_url(domain, base_path, version, relative_path)
-        if html_baseurl:
-            return f"{html_baseurl}/{relative_path}"
-        return relative_path
-
-    # Collect all documentation pages
-    docs = []
-
-    try:
-        # Get all document names from the environment
-        all_docs = list(app.env.all_docs.keys()) if hasattr(app.env, "all_docs") else []
-
-        for docname in sorted(all_docs):
-            # Skip internal/private pages
-            if docname.startswith("_"):
-                continue
-
-            # Get the page title
-            title = app.env.titles.get(docname, docname)
-            if hasattr(title, "astext"):
-                title = title.astext()
-
-            # Build the URL
-            url = make_url(docname + ".html")
-            docs.append({"title": str(title), "url": url, "docname": docname})
-
-    except Exception as e:
-        print(f"Warning: Could not discover pages for llms.txt: {e}")
-
-    # Deduplicate titles if enabled
-    # This adds a disambiguating suffix to duplicate titles based on their URL path
-    deduplicate = (
-        str(theme_options.get("llm_deduplicate_titles", "false")).lower() == "true"
-    )
-    if deduplicate:
-        # Count title occurrences
-        title_counts = {}
-        for doc in docs:
-            title_counts[doc["title"]] = title_counts.get(doc["title"], 0) + 1
-
-        # Find duplicates and add disambiguation
-        for doc in docs:
-            if title_counts[doc["title"]] > 1:
-                # Extract module/path info from docname for disambiguation
-                # e.g., "generated/torch.nn.GRU" -> "torch.nn.GRU"
-                docname = doc["docname"]
-
-                # Try to get a meaningful suffix from the docname
-                if "/" in docname:
-                    suffix = docname.split("/")[-1]
-                else:
-                    suffix = docname
-
-                # Remove "generated/" prefix if present (Sphinx autodoc convention)
-                if suffix.startswith("generated/"):
-                    suffix = suffix[10:]
-
-                # Only add suffix if it's different from the title
-                if suffix.lower() != doc["title"].lower():
-                    doc["title"] = f"{doc['title']} ({suffix})"
-
-    # Build the llms.txt content in Hugging Face style
-    lines = []
-
-    # Header
-    lines.append(f"# {project}")
-    lines.append("")
-
-    # Quote block with project description (for spec compliance)
-    # If llm_description is set, use it. Otherwise, generate a generic one from project name.
-    llm_description = theme_options.get("llm_description", "").strip()
-    if not llm_description:
-        # Generic fallback using Sphinx project name
-        llm_description = f"{project} documentation."
-
-    lines.append(f"> {llm_description}")
-    lines.append("")
-
-    lines.append("## Docs")
-    lines.append("")
-
-    # List all documentation pages
-    for doc in docs:
-        lines.append(f"- [{doc['title']}]({doc['url']})")
-
-    # Join content
-    content = "\n".join(lines)
-
-    # Write to site root
-    try:
-        dest_path.write_text(content, encoding="utf-8")
-        print(f"Generated llms.txt with {len(docs)} pages at: {dest_path}")
-    except Exception as e:
-        print(f"Warning: Could not write llms.txt to site root: {e}")
 
 
 # =============================================================================
@@ -679,7 +485,7 @@ def setup(app):
         # Write JS immediately during page context (high priority to run early)
         app.connect("html-page-context", _write_glossary_tippy_js, priority=900)
 
-    # Copy llms.txt to site root after build completes
+    # Generate llms.txt (and optionally .md files) after build completes
     app.connect("build-finished", _generate_llms_txt)
 
     if HAS_SPHINX_GALLERY:

--- a/pytorch_sphinx_theme2/llm_generation.py
+++ b/pytorch_sphinx_theme2/llm_generation.py
@@ -1,0 +1,578 @@
+"""LLM Navigation Guide (llms.txt) and markdown generation support.
+
+This module handles:
+- Generating llms.txt with page listings for LLM discovery
+- Converting Sphinx HTML output to clean markdown files
+- Generating llms-full.txt with all content concatenated
+"""
+
+import re
+import shutil
+from html import unescape
+from pathlib import Path
+
+
+def _html_to_markdown(html_content):
+    """Convert HTML content to clean markdown.
+
+    Extracts the main article/body content from a Sphinx-generated HTML page
+    and converts it to readable markdown. Uses BeautifulSoup if available,
+    otherwise falls back to regex-based conversion.
+    """
+    try:
+        from bs4 import BeautifulSoup, NavigableString, Tag
+
+        soup = BeautifulSoup(html_content, "html.parser")
+
+        # Remove script, style, nav, and sidebar elements
+        for tag in soup.find_all(
+            ["script", "style", "nav", "footer", "header", "aside"]
+        ):
+            tag.decompose()
+
+        # Remove Sphinx-specific non-content elements
+        for selector in [
+            ".headerlink",
+            ".sphinxsidebar",
+            ".related",
+            ".footer",
+            ".navigation",
+            ".breadcrumb",
+            ".date-info-last-verified",
+            '[role="navigation"]',
+            '[role="search"]',
+            ".search-button",
+        ]:
+            for el in soup.select(selector):
+                el.decompose()
+
+        # Try to find the main content area (Sphinx uses various containers)
+        content = (
+            soup.find("article")
+            or soup.find("div", class_="body")
+            or soup.find("div", class_="document")
+            or soup.find("div", {"role": "main"})
+            or soup.find("main")
+            or soup.body
+            or soup
+        )
+
+        def _convert_node(node):
+            """Recursively convert an HTML node to markdown."""
+            if isinstance(node, NavigableString):
+                text = str(node)
+                # Collapse whitespace but preserve single newlines
+                return text
+
+            if not isinstance(node, Tag):
+                return ""
+
+            tag_name = node.name
+
+            # Skip hidden elements
+            if node.get("style") and "display:none" in node.get("style", ""):
+                return ""
+
+            # Get inner content by recursing into children
+            inner = "".join(_convert_node(child) for child in node.children)
+
+            if tag_name in ("h1", "h2", "h3", "h4", "h5", "h6"):
+                level = int(tag_name[1])
+                prefix = "#" * level
+                text = inner.strip()
+                if text:
+                    return f"\n\n{prefix} {text}\n\n"
+                return ""
+
+            if tag_name == "p":
+                text = inner.strip()
+                if text:
+                    return f"\n\n{text}\n\n"
+                return ""
+
+            if tag_name == "br":
+                return "\n"
+
+            if tag_name == "a":
+                href = node.get("href", "")
+                text = inner.strip()
+                if href and text and not href.startswith("#"):
+                    return f"[{text}]({href})"
+                return text
+
+            if tag_name == "strong" or tag_name == "b":
+                text = inner.strip()
+                if text:
+                    return f"**{text}**"
+                return ""
+
+            if tag_name == "em" or tag_name == "i":
+                text = inner.strip()
+                if text:
+                    return f"*{text}*"
+                return ""
+
+            if tag_name == "code":
+                text = inner.strip()
+                if text:
+                    # Don't nest backticks
+                    if "`" in text:
+                        return text
+                    return f"`{text}`"
+                return ""
+
+            if tag_name == "pre":
+                # Code blocks - try to detect language from class
+                code_el = node.find("code")
+                lang = ""
+                classes = (code_el or node).get("class", [])
+                for cls in classes:
+                    if cls.startswith("language-") or cls.startswith("highlight-"):
+                        lang = cls.split("-", 1)[1]
+                        break
+
+                code_text = (code_el or node).get_text()
+                return f"\n\n```{lang}\n{code_text.strip()}\n```\n\n"
+
+            if tag_name == "blockquote":
+                text = inner.strip()
+                if text:
+                    quoted = "\n".join(
+                        f"> {line}" for line in text.split("\n")
+                    )
+                    return f"\n\n{quoted}\n\n"
+                return ""
+
+            if tag_name in ("ul", "ol"):
+                items = []
+                for idx, li in enumerate(node.find_all("li", recursive=False)):
+                    li_text = _convert_node(li).strip()
+                    if tag_name == "ol":
+                        items.append(f"{idx + 1}. {li_text}")
+                    else:
+                        items.append(f"- {li_text}")
+                if items:
+                    return "\n\n" + "\n".join(items) + "\n\n"
+                return ""
+
+            if tag_name == "li":
+                return inner.strip()
+
+            if tag_name == "table":
+                return _convert_table(node)
+
+            if tag_name == "img":
+                alt = node.get("alt", "")
+                src = node.get("src", "")
+                return f"![{alt}]({src})"
+
+            if tag_name == "hr":
+                return "\n\n---\n\n"
+
+            if tag_name in (
+                "div",
+                "section",
+                "article",
+                "span",
+                "dd",
+                "dt",
+                "dl",
+                "figure",
+                "figcaption",
+                "tbody",
+                "thead",
+                "tr",
+                "td",
+                "th",
+            ):
+                return inner
+
+            return inner
+
+        def _convert_table(table_node):
+            """Convert an HTML table to markdown."""
+            rows = []
+            for tr in table_node.find_all("tr"):
+                cells = []
+                for cell in tr.find_all(["td", "th"]):
+                    cell_text = _convert_node(cell).strip()
+                    # Replace pipes and newlines in cell content
+                    cell_text = cell_text.replace("|", "\\|").replace("\n", " ")
+                    cells.append(cell_text)
+                if cells:
+                    rows.append(cells)
+
+            if not rows:
+                return ""
+
+            # Build markdown table
+            lines = []
+            lines.append("| " + " | ".join(rows[0]) + " |")
+            lines.append("| " + " | ".join("---" for _ in rows[0]) + " |")
+            for row in rows[1:]:
+                # Pad row if needed
+                while len(row) < len(rows[0]):
+                    row.append("")
+                lines.append("| " + " | ".join(row[: len(rows[0])]) + " |")
+
+            return "\n\n" + "\n".join(lines) + "\n\n"
+
+        md = _convert_node(content)
+
+    except ImportError:
+        # Fallback: regex-based conversion when BeautifulSoup is not available
+        # Strip everything outside the body content
+        body_match = re.search(
+            r'<div class="body"[^>]*>(.*?)</div>\s*(?:<div class="clearer")',
+            html_content,
+            re.DOTALL,
+        )
+        if body_match:
+            text = body_match.group(1)
+        else:
+            text = html_content
+
+        # Remove script and style blocks
+        text = re.sub(r"<script[^>]*>.*?</script>", "", text, flags=re.DOTALL)
+        text = re.sub(r"<style[^>]*>.*?</style>", "", text, flags=re.DOTALL)
+
+        # Convert headings
+        for i in range(1, 7):
+            prefix = "#" * i
+            text = re.sub(
+                rf"<h{i}[^>]*>(.*?)</h{i}>",
+                rf"\n\n{prefix} \1\n\n",
+                text,
+                flags=re.DOTALL,
+            )
+
+        # Convert code blocks
+        text = re.sub(
+            r"<pre[^>]*><code[^>]*>(.*?)</code></pre>",
+            r"\n\n```\n\1\n```\n\n",
+            text,
+            flags=re.DOTALL,
+        )
+        text = re.sub(
+            r"<pre[^>]*>(.*?)</pre>",
+            r"\n\n```\n\1\n```\n\n",
+            text,
+            flags=re.DOTALL,
+        )
+
+        # Convert inline code
+        text = re.sub(r"<code[^>]*>(.*?)</code>", r"`\1`", text)
+
+        # Convert links
+        text = re.sub(r'<a[^>]*href="([^"]*)"[^>]*>(.*?)</a>', r"[\2](\1)", text)
+
+        # Convert bold and italic
+        text = re.sub(r"<(?:strong|b)>(.*?)</(?:strong|b)>", r"**\1**", text)
+        text = re.sub(r"<(?:em|i)>(.*?)</(?:em|i)>", r"*\1*", text)
+
+        # Convert list items
+        text = re.sub(r"<li[^>]*>(.*?)</li>", r"- \1", text, flags=re.DOTALL)
+
+        # Convert paragraphs
+        text = re.sub(r"<p[^>]*>(.*?)</p>", r"\n\n\1\n\n", text, flags=re.DOTALL)
+
+        # Strip remaining HTML tags
+        text = re.sub(r"<[^>]+>", "", text)
+
+        md = text
+
+    # Unescape HTML entities
+    md = unescape(md)
+
+    # Normalize Unicode punctuation to ASCII equivalents for maximum compatibility
+    md = md.replace("\u2018", "'").replace("\u2019", "'")   # smart single quotes
+    md = md.replace("\u201c", '"').replace("\u201d", '"')   # smart double quotes
+    md = md.replace("\u2013", "-").replace("\u2014", "--")  # en-dash, em-dash
+    md = md.replace("\u2026", "...")                        # ellipsis
+    md = md.replace("\u00a0", " ")                          # non-breaking space
+
+    # Clean up excessive whitespace
+    md = re.sub(r"\n{3,}", "\n\n", md)
+    md = re.sub(r" {2,}", " ", md)
+    md = md.strip()
+
+    return md
+
+
+def _generate_md_files(app, docs):
+    """Generate .md files from built HTML pages.
+
+    Args:
+        app: The Sphinx application object.
+        docs: List of doc dicts with 'docname' keys.
+
+    Returns:
+        Number of .md files successfully generated.
+    """
+    outdir = Path(app.outdir)
+    md_count = 0
+
+    for doc in docs:
+        docname = doc["docname"]
+        html_path = outdir / (docname + ".html")
+
+        if not html_path.is_file():
+            continue
+
+        try:
+            html_content = html_path.read_text(encoding="utf-8")
+            md_content = _html_to_markdown(html_content)
+
+            if not md_content.strip():
+                continue
+
+            md_path = outdir / (docname + ".md")
+            md_path.parent.mkdir(parents=True, exist_ok=True)
+            md_path.write_text(md_content, encoding="utf-8")
+            md_count += 1
+
+        except Exception as e:
+            print(f"Warning: Could not convert {docname}.html to markdown: {e}")
+
+    return md_count
+
+
+def _generate_llms_full_txt(app, docs, outdir):
+    """Generate llms-full.txt by concatenating all markdown content.
+
+    Per the llms.txt spec, llms-full.txt contains the full content of all
+    documentation pages in a single file for easy LLM ingestion.
+    """
+    project = app.config.project or "Documentation"
+    theme_options = app.config.html_theme_options or {}
+    llm_description = theme_options.get("llm_description", "").strip()
+    if not llm_description:
+        llm_description = f"{project} documentation."
+
+    sections = []
+    sections.append(f"# {project}\n\n> {llm_description}\n")
+
+    out_path = Path(outdir)
+    for doc in docs:
+        md_path = out_path / (doc["docname"] + ".md")
+        if md_path.is_file():
+            md_content = md_path.read_text(encoding="utf-8")
+            if md_content.strip():
+                sections.append(f"\n---\n\n{md_content}")
+
+    full_content = "\n".join(sections)
+    full_path = out_path / "llms-full.txt"
+
+    try:
+        full_path.write_text(full_content, encoding="utf-8")
+        print(f"Generated llms-full.txt at: {full_path}")
+    except Exception as e:
+        print(f"Warning: Could not write llms-full.txt: {e}")
+
+
+def _build_llms_url(domain, base_path, version, relative_path=""):
+    """Build a full URL for llms.txt links.
+
+    Args:
+        domain: The documentation domain (e.g., "docs.pytorch.org")
+        base_path: The base path after domain (e.g., "docs/", "vision/")
+        version: The documentation version (e.g., "stable", "2.0.0")
+        relative_path: The relative path to the page (e.g., "index.html")
+
+    Returns:
+        Full URL like "https://docs.pytorch.org/docs/stable/index.html"
+    """
+    # Ensure domain doesn't have trailing slash
+    domain = domain.rstrip("/")
+
+    # Ensure base_path has proper format (no leading slash, has trailing slash if non-empty)
+    base_path = base_path.strip("/")
+    if base_path:
+        base_path = base_path + "/"
+
+    # Ensure version doesn't have slashes
+    version = version.strip("/")
+
+    # Ensure relative_path doesn't have leading slash
+    relative_path = relative_path.lstrip("/")
+
+    # Build URL
+    if relative_path:
+        return f"https://{domain}/{base_path}{version}/{relative_path}"
+    else:
+        return f"https://{domain}/{base_path}{version}/"
+
+
+def _generate_llms_txt(app, exception):
+    """Dynamically generate llms.txt during documentation build.
+
+    The file is resolved in this order:
+
+    1. **Explicit disable** — ``llm_disabled = "true"`` skips generation entirely.
+    2. **Custom file** — ``llm_custom_file`` theme option pointing to a file
+       relative to the Sphinx source directory.
+    3. **Convention** — A file named ``llms.txt`` in the Sphinx source root.
+    4. **Auto-generation** — A simple page listing following the llms.txt spec,
+       with URLs resolved as:
+       a. ``llm_domain`` + ``llm_base_path`` theme options -> fully constructed URLs
+       b. Sphinx ``html_baseurl`` config -> baseurl + relative path
+       c. Relative URLs as a last resort
+
+    Enabled by default. Set ``llm_disabled = "true"`` to disable.
+    """
+    if exception is not None:
+        return  # Don't generate if build failed
+
+    if app.builder.name != "html":
+        return
+
+    # Enabled by default; opt-out with llm_disabled = "true"
+    theme_options = app.config.html_theme_options or {}
+    if str(theme_options.get("llm_disabled", "false")).lower() == "true":
+        return
+
+    dest_path = Path(app.outdir) / "llms.txt"
+
+    # --- 1. Explicit option: llm_custom_file ---
+    custom_file = theme_options.get("llm_custom_file", "").strip()
+    if custom_file:
+        custom_path = Path(app.srcdir) / custom_file
+        if custom_path.is_file():
+            shutil.copy2(custom_path, dest_path)
+            print(f"Copied custom llms.txt from: {custom_path}")
+            return
+        else:
+            print(
+                f"Warning: llm_custom_file '{custom_file}' not found at "
+                f"{custom_path}, falling back to auto-generation"
+            )
+
+    # --- 2. Convention: llms.txt in the source root ---
+    source_llms = Path(app.srcdir) / "llms.txt"
+    if source_llms.is_file():
+        shutil.copy2(source_llms, dest_path)
+        print(f"Using project-provided llms.txt from: {source_llms}")
+        return
+
+    # --- 3. Auto-generation ---
+    # Get configuration
+    project = app.config.project or "Documentation"
+    version = app.config.version or "latest"
+    domain = theme_options.get("llm_domain", "").strip()
+    base_path = theme_options.get("llm_base_path", "").strip()
+    generate_md = (
+        str(theme_options.get("llm_generate_md", "true")).lower() == "true"
+    )
+
+    # Resolve the base URL for links:
+    # Priority: llm_domain > html_baseurl > relative
+    html_baseurl = getattr(app.config, "html_baseurl", None) or ""
+    html_baseurl = html_baseurl.strip().rstrip("/")
+
+    # File extension for links: .md when markdown generation is enabled, .html otherwise
+    link_ext = ".md" if generate_md else ".html"
+
+    def make_url(relative_path):
+        if domain:
+            return _build_llms_url(domain, base_path, version, relative_path)
+        if html_baseurl:
+            return f"{html_baseurl}/{relative_path}"
+        return relative_path
+
+    # Collect all documentation pages
+    docs = []
+
+    try:
+        # Get all document names from the environment
+        all_docs = list(app.env.all_docs.keys()) if hasattr(app.env, "all_docs") else []
+
+        for docname in sorted(all_docs):
+            # Skip internal/private pages
+            if docname.startswith("_"):
+                continue
+
+            # Get the page title
+            title = app.env.titles.get(docname, docname)
+            if hasattr(title, "astext"):
+                title = title.astext()
+
+            # Build the URL (use .md or .html based on config)
+            url = make_url(docname + link_ext)
+            docs.append({"title": str(title), "url": url, "docname": docname})
+
+    except Exception as e:
+        print(f"Warning: Could not discover pages for llms.txt: {e}")
+
+    # Generate .md files from HTML if enabled
+    if generate_md and docs:
+        md_count = _generate_md_files(app, docs)
+        print(f"Generated {md_count} markdown files from HTML pages")
+
+        # Also generate llms-full.txt with all content concatenated
+        _generate_llms_full_txt(app, docs, app.outdir)
+
+    # Deduplicate titles if enabled
+    # This adds a disambiguating suffix to duplicate titles based on their URL path
+    deduplicate = (
+        str(theme_options.get("llm_deduplicate_titles", "false")).lower() == "true"
+    )
+    if deduplicate:
+        # Count title occurrences
+        title_counts = {}
+        for doc in docs:
+            title_counts[doc["title"]] = title_counts.get(doc["title"], 0) + 1
+
+        # Find duplicates and add disambiguation
+        for doc in docs:
+            if title_counts[doc["title"]] > 1:
+                # Extract module/path info from docname for disambiguation
+                # e.g., "generated/torch.nn.GRU" -> "torch.nn.GRU"
+                docname = doc["docname"]
+
+                # Try to get a meaningful suffix from the docname
+                if "/" in docname:
+                    suffix = docname.split("/")[-1]
+                else:
+                    suffix = docname
+
+                # Remove "generated/" prefix if present (Sphinx autodoc convention)
+                if suffix.startswith("generated/"):
+                    suffix = suffix[10:]
+
+                # Only add suffix if it's different from the title
+                if suffix.lower() != doc["title"].lower():
+                    doc["title"] = f"{doc['title']} ({suffix})"
+
+    # Build the llms.txt content in Hugging Face style
+    lines = []
+
+    # Header
+    lines.append(f"# {project}")
+    lines.append("")
+
+    # Quote block with project description (for spec compliance)
+    # If llm_description is set, use it. Otherwise, generate a generic one from project name.
+    llm_description = theme_options.get("llm_description", "").strip()
+    if not llm_description:
+        # Generic fallback using Sphinx project name
+        llm_description = f"{project} documentation."
+
+    lines.append(f"> {llm_description}")
+    lines.append("")
+
+    lines.append("## Docs")
+    lines.append("")
+
+    # List all documentation pages
+    for doc in docs:
+        lines.append(f"- [{doc['title']}]({doc['url']})")
+
+    # Join content
+    content = "\n".join(lines)
+
+    # Write to site root
+    try:
+        dest_path.write_text(content, encoding="utf-8")
+        print(f"Generated llms.txt with {len(docs)} pages at: {dest_path}")
+    except Exception as e:
+        print(f"Warning: Could not write llms.txt to site root: {e}")

--- a/pytorch_sphinx_theme2/theme.conf
+++ b/pytorch_sphinx_theme2/theme.conf
@@ -70,4 +70,8 @@ llm_disabled = false
 llm_custom_file =
 # Set to true to add disambiguating suffixes to duplicate titles
 # e.g., "GRU" becomes "GRU (torch.nn.GRU)" and "GRU (torch.nn.GRUCell)"
+# Set to true to deduplicate titles
 llm_deduplicate_titles = false
+# Set to true to generate .md files from HTML and link to them in llms.txt
+# Also generates llms-full.txt with all content concatenated
+llm_generate_md = true

--- a/tests/test_llm_markdown.py
+++ b/tests/test_llm_markdown.py
@@ -1,0 +1,304 @@
+"""Tests for LLM markdown generation (_html_to_markdown and related functions)."""
+
+import re
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from pytorch_sphinx_theme2 import (
+    _html_to_markdown,
+    _generate_md_files,
+    _generate_llms_full_txt,
+)
+
+
+# =============================================================================
+# _html_to_markdown tests
+# =============================================================================
+
+
+class TestHtmlToMarkdownHeadings:
+    def test_h1(self):
+        md = _html_to_markdown("<h1>Title</h1>")
+        assert "# Title" in md
+
+    def test_h2(self):
+        md = _html_to_markdown("<h2>Section</h2>")
+        assert "## Section" in md
+
+    def test_h3(self):
+        md = _html_to_markdown("<h3>Subsection</h3>")
+        assert "### Subsection" in md
+
+    def test_headerlinks_stripped(self):
+        html = '<h1>Title<a class="headerlink" href="#">&para;</a></h1>'
+        md = _html_to_markdown(html)
+        assert "headerlink" not in md
+        assert "\u00b6" not in md  # paragraph sign stripped
+
+
+class TestHtmlToMarkdownInlineFormatting:
+    def test_bold(self):
+        md = _html_to_markdown("<p><strong>bold</strong></p>")
+        assert "**bold**" in md
+
+    def test_italic(self):
+        md = _html_to_markdown("<p><em>italic</em></p>")
+        assert "*italic*" in md
+
+    def test_inline_code(self):
+        md = _html_to_markdown("<p><code>some_func()</code></p>")
+        assert "`some_func()`" in md
+
+    def test_link(self):
+        md = _html_to_markdown('<p><a href="https://example.com">click</a></p>')
+        assert "[click](https://example.com)" in md
+
+
+class TestHtmlToMarkdownCodeBlocks:
+    def test_pre_code(self):
+        html = "<pre><code>x = 1\ny = 2</code></pre>"
+        md = _html_to_markdown(html)
+        assert "```" in md
+        assert "x = 1" in md
+
+    def test_language_class(self):
+        html = '<pre><code class="language-python">print("hi")</code></pre>'
+        md = _html_to_markdown(html)
+        assert "```python" in md
+
+
+class TestHtmlToMarkdownLists:
+    def test_unordered_list(self):
+        html = "<ul><li>one</li><li>two</li></ul>"
+        md = _html_to_markdown(html)
+        assert "- one" in md
+        assert "- two" in md
+
+    def test_ordered_list(self):
+        html = "<ol><li>first</li><li>second</li></ol>"
+        md = _html_to_markdown(html)
+        assert "1. first" in md
+        assert "2. second" in md
+
+
+class TestHtmlToMarkdownTables:
+    def test_simple_table(self):
+        html = """
+        <table>
+        <tr><th>Name</th><th>Value</th></tr>
+        <tr><td>foo</td><td>bar</td></tr>
+        </table>
+        """
+        md = _html_to_markdown(html)
+        assert "| Name | Value |" in md
+        assert "| foo | bar |" in md
+        assert "| --- | --- |" in md
+
+
+class TestHtmlToMarkdownContentExtraction:
+    def test_extracts_article_content(self):
+        html = """
+        <html><body>
+        <nav>Navigation stuff</nav>
+        <article><h1>Real Content</h1><p>Hello world</p></article>
+        <footer>Footer stuff</footer>
+        </body></html>
+        """
+        md = _html_to_markdown(html)
+        assert "Real Content" in md
+        assert "Hello world" in md
+        assert "Navigation stuff" not in md
+        assert "Footer stuff" not in md
+
+    def test_strips_date_info(self):
+        html = """
+        <article>
+        <h1>Page Title</h1>
+        <p class="date-info-last-verified">Created On: Jan 1, 2024 | Last Updated On: Feb 2, 2024</p>
+        <p>Actual content here.</p>
+        </article>
+        """
+        md = _html_to_markdown(html)
+        assert "Created On:" not in md
+        assert "Actual content here" in md
+
+    def test_strips_search_elements(self):
+        html = """
+        <article>
+        <div role="search"><input type="text"></div>
+        <p>Content</p>
+        </article>
+        """
+        md = _html_to_markdown(html)
+        assert "Content" in md
+
+
+class TestHtmlToMarkdownUnicode:
+    def test_smart_quotes_normalized(self):
+        html = "<p>it\u2019s a \u201ctest\u201d</p>"
+        md = _html_to_markdown(html)
+        assert "it's" in md
+        assert '"test"' in md
+
+    def test_em_dash_normalized(self):
+        html = "<p>one\u2014two</p>"
+        md = _html_to_markdown(html)
+        assert "one--two" in md
+
+    def test_en_dash_normalized(self):
+        html = "<p>1\u20132</p>"
+        md = _html_to_markdown(html)
+        assert "1-2" in md
+
+    def test_ellipsis_normalized(self):
+        html = "<p>wait\u2026</p>"
+        md = _html_to_markdown(html)
+        assert "wait..." in md
+
+    def test_html_entities_unescaped(self):
+        html = "<p>&amp; &lt; &gt; &quot;</p>"
+        md = _html_to_markdown(html)
+        assert "& < >" in md
+
+
+class TestHtmlToMarkdownMisc:
+    def test_empty_html(self):
+        md = _html_to_markdown("")
+        assert md == ""
+
+    def test_whitespace_cleanup(self):
+        html = "<p>hello</p>\n\n\n\n\n<p>world</p>"
+        md = _html_to_markdown(html)
+        assert "\n\n\n" not in md
+
+    def test_blockquote(self):
+        html = "<blockquote><p>quoted text</p></blockquote>"
+        md = _html_to_markdown(html)
+        assert "> quoted text" in md
+
+    def test_image(self):
+        html = '<img src="pic.png" alt="A picture">'
+        md = _html_to_markdown(html)
+        assert "![A picture](pic.png)" in md
+
+    def test_horizontal_rule(self):
+        html = "<p>above</p><hr><p>below</p>"
+        md = _html_to_markdown(html)
+        assert "---" in md
+
+
+# =============================================================================
+# _generate_md_files tests
+# =============================================================================
+
+
+class TestGenerateMdFiles:
+    def test_generates_md_from_html(self, tmp_path):
+        # Create a fake HTML file
+        html_content = "<article><h1>Test Page</h1><p>Hello world</p></article>"
+        (tmp_path / "page.html").write_text(html_content, encoding="utf-8")
+
+        app = MagicMock()
+        app.outdir = str(tmp_path)
+
+        docs = [{"docname": "page"}]
+        count = _generate_md_files(app, docs)
+
+        assert count == 1
+        md_path = tmp_path / "page.md"
+        assert md_path.exists()
+        content = md_path.read_text(encoding="utf-8")
+        assert "# Test Page" in content
+        assert "Hello world" in content
+
+    def test_skips_missing_html(self, tmp_path):
+        app = MagicMock()
+        app.outdir = str(tmp_path)
+
+        docs = [{"docname": "nonexistent"}]
+        count = _generate_md_files(app, docs)
+        assert count == 0
+
+    def test_creates_subdirectories(self, tmp_path):
+        subdir = tmp_path / "community"
+        subdir.mkdir()
+        html_content = "<article><h1>Guide</h1><p>Content</p></article>"
+        (subdir / "guide.html").write_text(html_content, encoding="utf-8")
+
+        app = MagicMock()
+        app.outdir = str(tmp_path)
+
+        docs = [{"docname": "community/guide"}]
+        count = _generate_md_files(app, docs)
+
+        assert count == 1
+        assert (subdir / "guide.md").exists()
+
+    def test_skips_empty_conversion(self, tmp_path):
+        # HTML with only non-content elements
+        html_content = "<nav>nav only</nav>"
+        (tmp_path / "empty.html").write_text(html_content, encoding="utf-8")
+
+        app = MagicMock()
+        app.outdir = str(tmp_path)
+
+        docs = [{"docname": "empty"}]
+        count = _generate_md_files(app, docs)
+        # May or may not produce output depending on fallback behavior,
+        # but should not crash
+        assert count >= 0
+
+
+# =============================================================================
+# _generate_llms_full_txt tests
+# =============================================================================
+
+
+class TestGenerateLlmsFullTxt:
+    def test_generates_concatenated_file(self, tmp_path):
+        # Create some .md files
+        (tmp_path / "page1.md").write_text("# Page 1\n\nContent one.", encoding="utf-8")
+        (tmp_path / "page2.md").write_text("# Page 2\n\nContent two.", encoding="utf-8")
+
+        app = MagicMock()
+        app.config.project = "TestProject"
+        app.config.html_theme_options = {"llm_description": "A test project."}
+
+        docs = [{"docname": "page1"}, {"docname": "page2"}]
+        _generate_llms_full_txt(app, docs, str(tmp_path))
+
+        full_path = tmp_path / "llms-full.txt"
+        assert full_path.exists()
+        content = full_path.read_text(encoding="utf-8")
+        assert "# TestProject" in content
+        assert "A test project." in content
+        assert "Content one." in content
+        assert "Content two." in content
+
+    def test_uses_default_description(self, tmp_path):
+        (tmp_path / "page.md").write_text("# Page\n\nContent.", encoding="utf-8")
+
+        app = MagicMock()
+        app.config.project = "MyDocs"
+        app.config.html_theme_options = {}
+
+        docs = [{"docname": "page"}]
+        _generate_llms_full_txt(app, docs, str(tmp_path))
+
+        content = (tmp_path / "llms-full.txt").read_text(encoding="utf-8")
+        assert "MyDocs documentation." in content
+
+    def test_skips_missing_md(self, tmp_path):
+        app = MagicMock()
+        app.config.project = "Test"
+        app.config.html_theme_options = {}
+
+        docs = [{"docname": "missing"}]
+        _generate_llms_full_txt(app, docs, str(tmp_path))
+
+        content = (tmp_path / "llms-full.txt").read_text(encoding="utf-8")
+        assert "# Test" in content
+        # Should just have the header, no page content
+        assert "---" not in content


### PR DESCRIPTION
Add llm_generate_md theme option that converts Sphinx HTML output to clean .md files and links to them in llms.txt instead of .html files.
Also generates llms-full.txt with all page content concatenated.
  - Add _html_to_markdown() with BeautifulSoup (+ regex fallback)
  - Strip theme-injected metadata (date info, headerlinks, nav elements)
  - Normalize Unicode punctuation to ASCII for compatibility
  - Generate llms-full.txt per the llms.txt spec
  - Register llm_generate_md option in theme.conf - True by default
  - Add 33 tests covering conversion, file generation, and edge cases
  - Add .claude/ to .gitignore

Example generated .md files: 
HTML: https://deploy-preview-239--pytorchsphinxtheme.netlify.app/community/build_ci_governance
.md: https://deploy-preview-239--pytorchsphinxtheme.netlify.app/community/build_ci_governance.md

HTML: https://deploy-preview-239--pytorchsphinxtheme.netlify.app/community/design
.md: https://deploy-preview-239--pytorchsphinxtheme.netlify.app/community/design.md 

llms.txt: https://deploy-preview-239--pytorchsphinxtheme.netlify.app/llms.txt
llms-full.txt: https://deploy-preview-239--pytorchsphinxtheme.netlify.app/llms-full.txt 