### PR TITLE
Fix red X thumbnail appearing in Google search results

### DIFF
--- a/pytorch_sphinx_theme2/static/scss/_components.scss
+++ b/pytorch_sphinx_theme2/static/scss/_components.scss
@@ -334,6 +334,7 @@ a.btn {
     appearance: none;
     background: transparent;
     border: 1px solid var(--pst-color-background);
+    width: 1.3125rem;
     height: 1.3125rem;
     position: absolute;
     bottom: 42px;
@@ -341,6 +342,26 @@ a.btn {
     top: 0;
     cursor: pointer;
     outline: none;
+    padding: 0;
+
+    &::before,
+    &::after {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 100%;
+      height: 2px;
+      background-color: #ee4c2a;
+    }
+
+    &::before {
+      transform: translate(-50%, -50%) rotate(45deg);
+    }
+
+    &::after {
+      transform: translate(-50%, -50%) rotate(-45deg);
+    }
 
     @media screen and (min-width: 768px) {
       right: 20%;

--- a/pytorch_sphinx_theme2/templates/cookie_banner.html
+++ b/pytorch_sphinx_theme2/templates/cookie_banner.html
@@ -1,6 +1,6 @@
-<div class="cookie-banner-wrapper">
+<div class="cookie-banner-wrapper" data-nosnippet>
   <div class="container">
     <p class="gdpr-notice">To analyze traffic and optimize your experience, we serve cookies on this site. By clicking or navigating, you agree to allow our usage of cookies. As the current maintainers of this site, Facebook’s Cookies Policy applies. Learn more, including about available controls: <a href="https://opensource.fb.com/legal/cookie-policy">Cookies Policy</a>.</p>
-    <img class="close-button" src="{{ pathto('_static/img/pytorch-x.svg', 1) }}">
+    <button class="close-button" aria-label="Close cookie banner"></button>
   </div>
 </div>


### PR DESCRIPTION
- Google was picking up the pytorch-x.svg image (red X close button on the cookie banner) as the page thumbnail in search results, since it was     
  served as an <img> tag — one of the few crawlable images on most doc pages
- Replaced the <img> tag in the cookie banner with a CSS-only <button> using ::before/::after pseudo-elements to draw the X, so there's no image for
   Google to index                                                                                                                                    
- Added data-nosnippet attribute to the cookie banner wrapper as an extra signal to Google to exclude it from search snippets
                                                                                                                                                      
Test plan                                                                                                                                           
                                                                                                                                                      
  - Verify the cookie banner close button still renders as a red X and is clickable                                                                   
  - Verify the close button styling is correct across breakpoints (mobile, tablet, desktop)
  - Inspect the page source to confirm no <img> tag referencing pytorch-x.svg remains                                                                 
  - After reindexing, confirm Google search results no longer show the red X thumbnail                                           