### PR TITLE
Bump theme to 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to pytorch_sphinx_theme2 are documented here.
 
+## v0.4.7
+
+### New Features
+
+- **Markdown Generation for LLM Docs** (PR #239) — Refactored the LLM content generation into a dedicated `llm_generation.py` module with a new markdown generation function. Added support for new theme options and comprehensive test coverage.
+
+- **Collapsible List Component** (PR #240) — Added collapsible list styles and JavaScript for C++ documentation pages. Supports nested expandable/collapsible sections with smooth animations.
+
+### Bug Fixes
+
+- **Right Nav Scroll Fix** (PR #240) — Fixed right-side navigation scroll behavior in the layout template.
+
+- **Google Search Thumbnail Fix** (PR #241) — Fixed red X thumbnail appearing in Google search results by updating component styles and cookie banner markup.
+
+---
+
 ## v0.4.6
 
 ### Improvements

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="svekars@meta.com",
     url="https://github.com/pytorch/pytorch_sphinx_theme",
     license="MIT",
-    version="0.4.6",
+    version="0.4.7",
     install_requires=[
         "pydata-sphinx-theme==0.15.4",
         "sphinx>=5.3.0,<=7.2.6",


### PR DESCRIPTION
- Bump pytorch_sphinx_theme2 version from 0.4.6 to 0.4.7                                                                       
- Update CHANGELOG with changes since v0.4.6:                                                                                  
    - Markdown generation for LLM docs (PR #239)                                                                                 
    - Collapsible list component for C++ docs (PR #240)                                                                          
    - Right nav scroll fix (PR #240)                                                                                             
    - Google search thumbnail fix (PR #241)                                                                                      
- Published to PyPI: https://pypi.org/project/pytorch-sphinx-theme2/0.4.7/                                                     
                                                                                                                                 
## Test plan                                                                                                                   
                                                                                                                                 
- [x] Verify package installs correctly: `pip install pytorch_sphinx_theme2==0.4.7`                                            
- [x] Verify docs build with the new version  