### PR TITLE
Parallelize markdown generation with ProcessPoolExecutor

### DIFF
--- a/pytorch_sphinx_theme2/llm_generation.py
+++ b/pytorch_sphinx_theme2/llm_generation.py
@@ -8,6 +8,7 @@ This module handles:
 
 import re
 import shutil
+from concurrent.futures import ProcessPoolExecutor, as_completed
 from html import unescape
 from pathlib import Path
 
@@ -299,49 +300,77 @@ def _html_to_markdown(html_content):
     return md
 
 
+def _convert_single_doc(args):
+    """Convert a single HTML doc to markdown. Top-level function for multiprocessing.
+
+    Args:
+        args: Tuple of (docname, outdir_str).
+
+    Returns:
+        Tuple of (docname, md_content) on success, or (docname, None) on failure.
+    """
+    docname, outdir_str = args
+    outdir = Path(outdir_str)
+    html_path = outdir / (docname + ".html")
+
+    if not html_path.is_file():
+        return (docname, None)
+
+    try:
+        html_content = html_path.read_text(encoding="utf-8")
+        md_content = _html_to_markdown(html_content)
+
+        if not md_content.strip():
+            return (docname, None)
+
+        md_path = outdir / (docname + ".md")
+        md_path.parent.mkdir(parents=True, exist_ok=True)
+        md_path.write_text(md_content, encoding="utf-8")
+        return (docname, md_content)
+
+    except Exception as e:
+        print(f"Warning: Could not convert {docname}.html to markdown: {e}")
+        return (docname, None)
+
+
 def _generate_md_files(app, docs):
-    """Generate .md files from built HTML pages.
+    """Generate .md files from built HTML pages using parallel processing.
 
     Args:
         app: The Sphinx application object.
         docs: List of doc dicts with 'docname' keys.
 
     Returns:
-        Number of .md files successfully generated.
+        Dict mapping docname -> md_content for successfully converted pages.
     """
-    outdir = Path(app.outdir)
-    md_count = 0
+    outdir_str = str(app.outdir)
+    args_list = [(doc["docname"], outdir_str) for doc in docs]
+    results = {}
 
-    for doc in docs:
-        docname = doc["docname"]
-        html_path = outdir / (docname + ".html")
+    with ProcessPoolExecutor() as executor:
+        futures = {
+            executor.submit(_convert_single_doc, args): args[0]
+            for args in args_list
+        }
+        for future in as_completed(futures):
+            docname, md_content = future.result()
+            if md_content is not None:
+                results[docname] = md_content
 
-        if not html_path.is_file():
-            continue
-
-        try:
-            html_content = html_path.read_text(encoding="utf-8")
-            md_content = _html_to_markdown(html_content)
-
-            if not md_content.strip():
-                continue
-
-            md_path = outdir / (docname + ".md")
-            md_path.parent.mkdir(parents=True, exist_ok=True)
-            md_path.write_text(md_content, encoding="utf-8")
-            md_count += 1
-
-        except Exception as e:
-            print(f"Warning: Could not convert {docname}.html to markdown: {e}")
-
-    return md_count
+    return results
 
 
-def _generate_llms_full_txt(app, docs, outdir):
+def _generate_llms_full_txt(app, docs, outdir, md_contents):
     """Generate llms-full.txt by concatenating all markdown content.
 
     Per the llms.txt spec, llms-full.txt contains the full content of all
     documentation pages in a single file for easy LLM ingestion.
+
+    Args:
+        app: The Sphinx application object.
+        docs: List of doc dicts with 'docname' keys.
+        outdir: The output directory path.
+        md_contents: Dict mapping docname -> md_content (from _generate_md_files).
     """
     project = app.config.project or "Documentation"
     theme_options = app.config.html_theme_options or {}
@@ -352,16 +381,13 @@ def _generate_llms_full_txt(app, docs, outdir):
     sections = []
     sections.append(f"# {project}\n\n> {llm_description}\n")
 
-    out_path = Path(outdir)
     for doc in docs:
-        md_path = out_path / (doc["docname"] + ".md")
-        if md_path.is_file():
-            md_content = md_path.read_text(encoding="utf-8")
-            if md_content.strip():
-                sections.append(f"\n---\n\n{md_content}")
+        md_content = md_contents.get(doc["docname"])
+        if md_content and md_content.strip():
+            sections.append(f"\n---\n\n{md_content}")
 
     full_content = "\n".join(sections)
-    full_path = out_path / "llms-full.txt"
+    full_path = Path(outdir) / "llms-full.txt"
 
     try:
         full_path.write_text(full_content, encoding="utf-8")
@@ -505,11 +531,11 @@ def _generate_llms_txt(app, exception):
 
     # Generate .md files from HTML if enabled
     if generate_md and docs:
-        md_count = _generate_md_files(app, docs)
-        print(f"Generated {md_count} markdown files from HTML pages")
+        md_contents = _generate_md_files(app, docs)
+        print(f"Generated {len(md_contents)} markdown files from HTML pages")
 
-        # Also generate llms-full.txt with all content concatenated
-        _generate_llms_full_txt(app, docs, app.outdir)
+        # Also generate llms-full.txt with all content concatenated (using in-memory content)
+        _generate_llms_full_txt(app, docs, app.outdir, md_contents)
 
     # Deduplicate titles if enabled
     # This adds a disambiguating suffix to duplicate titles based on their URL path

--- a/pytorch_sphinx_theme2/llm_generation.py
+++ b/pytorch_sphinx_theme2/llm_generation.py
@@ -336,6 +336,10 @@ def _convert_single_doc(args):
 def _generate_md_files(app, docs):
     """Generate .md files from built HTML pages using parallel processing.
 
+    Uses ProcessPoolExecutor for parallel conversion, with automatic fallback
+    to sequential processing if multiprocessing is unavailable (e.g., in
+    sandboxed build environments like Netlify).
+
     Args:
         app: The Sphinx application object.
         docs: List of doc dicts with 'docname' keys.
@@ -347,13 +351,21 @@ def _generate_md_files(app, docs):
     args_list = [(doc["docname"], outdir_str) for doc in docs]
     results = {}
 
-    with ProcessPoolExecutor() as executor:
-        futures = {
-            executor.submit(_convert_single_doc, args): args[0]
-            for args in args_list
-        }
-        for future in as_completed(futures):
-            docname, md_content = future.result()
+    try:
+        with ProcessPoolExecutor() as executor:
+            futures = {
+                executor.submit(_convert_single_doc, args): args[0]
+                for args in args_list
+            }
+            for future in as_completed(futures):
+                docname, md_content = future.result()
+                if md_content is not None:
+                    results[docname] = md_content
+    except (OSError, RuntimeError) as e:
+        print(f"Parallel processing unavailable ({e}), falling back to sequential")
+        results = {}
+        for args in args_list:
+            docname, md_content = _convert_single_doc(args)
             if md_content is not None:
                 results[docname] = md_content
 

--- a/tests/test_llm_markdown.py
+++ b/tests/test_llm_markdown.py
@@ -1,6 +1,8 @@
 """Tests for LLM markdown generation (_html_to_markdown and related functions)."""
 
 import re
+import shutil
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -204,22 +206,22 @@ class TestGenerateMdFiles:
         app.outdir = str(tmp_path)
 
         docs = [{"docname": "page"}]
-        count = _generate_md_files(app, docs)
+        results = _generate_md_files(app, docs)
 
-        assert count == 1
+        assert len(results) == 1
+        assert "page" in results
+        assert "# Test Page" in results["page"]
+        assert "Hello world" in results["page"]
         md_path = tmp_path / "page.md"
         assert md_path.exists()
-        content = md_path.read_text(encoding="utf-8")
-        assert "# Test Page" in content
-        assert "Hello world" in content
 
     def test_skips_missing_html(self, tmp_path):
         app = MagicMock()
         app.outdir = str(tmp_path)
 
         docs = [{"docname": "nonexistent"}]
-        count = _generate_md_files(app, docs)
-        assert count == 0
+        results = _generate_md_files(app, docs)
+        assert len(results) == 0
 
     def test_creates_subdirectories(self, tmp_path):
         subdir = tmp_path / "community"
@@ -231,9 +233,10 @@ class TestGenerateMdFiles:
         app.outdir = str(tmp_path)
 
         docs = [{"docname": "community/guide"}]
-        count = _generate_md_files(app, docs)
+        results = _generate_md_files(app, docs)
 
-        assert count == 1
+        assert len(results) == 1
+        assert "community/guide" in results
         assert (subdir / "guide.md").exists()
 
     def test_skips_empty_conversion(self, tmp_path):
@@ -245,10 +248,10 @@ class TestGenerateMdFiles:
         app.outdir = str(tmp_path)
 
         docs = [{"docname": "empty"}]
-        count = _generate_md_files(app, docs)
+        results = _generate_md_files(app, docs)
         # May or may not produce output depending on fallback behavior,
         # but should not crash
-        assert count >= 0
+        assert isinstance(results, dict)
 
 
 # =============================================================================
@@ -258,16 +261,16 @@ class TestGenerateMdFiles:
 
 class TestGenerateLlmsFullTxt:
     def test_generates_concatenated_file(self, tmp_path):
-        # Create some .md files
-        (tmp_path / "page1.md").write_text("# Page 1\n\nContent one.", encoding="utf-8")
-        (tmp_path / "page2.md").write_text("# Page 2\n\nContent two.", encoding="utf-8")
-
         app = MagicMock()
         app.config.project = "TestProject"
         app.config.html_theme_options = {"llm_description": "A test project."}
 
         docs = [{"docname": "page1"}, {"docname": "page2"}]
-        _generate_llms_full_txt(app, docs, str(tmp_path))
+        md_contents = {
+            "page1": "# Page 1\n\nContent one.",
+            "page2": "# Page 2\n\nContent two.",
+        }
+        _generate_llms_full_txt(app, docs, str(tmp_path), md_contents)
 
         full_path = tmp_path / "llms-full.txt"
         assert full_path.exists()
@@ -278,14 +281,13 @@ class TestGenerateLlmsFullTxt:
         assert "Content two." in content
 
     def test_uses_default_description(self, tmp_path):
-        (tmp_path / "page.md").write_text("# Page\n\nContent.", encoding="utf-8")
-
         app = MagicMock()
         app.config.project = "MyDocs"
         app.config.html_theme_options = {}
 
         docs = [{"docname": "page"}]
-        _generate_llms_full_txt(app, docs, str(tmp_path))
+        md_contents = {"page": "# Page\n\nContent."}
+        _generate_llms_full_txt(app, docs, str(tmp_path), md_contents)
 
         content = (tmp_path / "llms-full.txt").read_text(encoding="utf-8")
         assert "MyDocs documentation." in content
@@ -296,9 +298,167 @@ class TestGenerateLlmsFullTxt:
         app.config.html_theme_options = {}
 
         docs = [{"docname": "missing"}]
-        _generate_llms_full_txt(app, docs, str(tmp_path))
+        md_contents = {}
+        _generate_llms_full_txt(app, docs, str(tmp_path), md_contents)
 
         content = (tmp_path / "llms-full.txt").read_text(encoding="utf-8")
         assert "# Test" in content
         # Should just have the header, no page content
         assert "---" not in content
+
+
+# =============================================================================
+# Parallelism tests
+# =============================================================================
+
+PYTORCH_DOCS_HTML = Path("/data/users/svekars/pytorch/docs/cpp/build/html")
+
+
+class TestParallelConversion:
+    """Test that parallel markdown generation works correctly and is faster."""
+
+    @pytest.fixture
+    def pytorch_html_dir(self, tmp_path):
+        """Copy PyTorch C++ docs HTML files to a temp dir for testing."""
+        if not PYTORCH_DOCS_HTML.exists():
+            pytest.skip("PyTorch C++ docs not built; run the docs build first")
+
+        html_files = list(PYTORCH_DOCS_HTML.rglob("*.html"))
+        if len(html_files) < 5:
+            pytest.skip("Not enough HTML files for a meaningful parallelism test")
+
+        # Copy HTML files preserving directory structure
+        for html_file in html_files:
+            rel = html_file.relative_to(PYTORCH_DOCS_HTML)
+            dest = tmp_path / rel
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(html_file, dest)
+
+        return tmp_path, html_files
+
+    def _build_docs_list(self, html_dir, html_files):
+        """Build docs list from HTML files relative to html_dir."""
+        docs = []
+        for f in html_files:
+            rel = f.relative_to(PYTORCH_DOCS_HTML)
+            docname = str(rel.with_suffix(""))
+            docs.append({"docname": docname})
+        return docs
+
+    def test_parallel_produces_valid_markdown(self, pytorch_html_dir):
+        """All converted files should contain valid, non-empty markdown."""
+        tmp_path, html_files = pytorch_html_dir
+        docs = self._build_docs_list(tmp_path, html_files)
+
+        app = MagicMock()
+        app.outdir = str(tmp_path)
+
+        results = _generate_md_files(app, docs)
+
+        assert len(results) > 0, "Should convert at least some pages"
+        for docname, md_content in results.items():
+            assert isinstance(md_content, str)
+            assert len(md_content.strip()) > 0, f"{docname} produced empty markdown"
+            # Check that .md file was written to disk
+            md_path = tmp_path / (docname + ".md")
+            assert md_path.exists(), f"{docname}.md was not written to disk"
+
+    def test_parallel_results_match_sequential(self, pytorch_html_dir):
+        """Parallel results should be identical to sequential conversion."""
+        tmp_path, html_files = pytorch_html_dir
+        docs = self._build_docs_list(tmp_path, html_files)
+
+        # Run sequential conversion
+        sequential_results = {}
+        for doc in docs:
+            html_path = tmp_path / (doc["docname"] + ".html")
+            if html_path.is_file():
+                html_content = html_path.read_text(encoding="utf-8")
+                md = _html_to_markdown(html_content)
+                if md.strip():
+                    sequential_results[doc["docname"]] = md
+
+        # Run parallel conversion (in a fresh tmp dir to avoid .md file conflicts)
+        tmp_path2 = tmp_path.parent / "parallel_copy"
+        shutil.copytree(tmp_path, tmp_path2, dirs_exist_ok=True)
+        # Remove any .md files from the copy
+        for md_file in tmp_path2.rglob("*.md"):
+            md_file.unlink()
+
+        app = MagicMock()
+        app.outdir = str(tmp_path2)
+
+        parallel_results = _generate_md_files(app, docs)
+
+        assert set(parallel_results.keys()) == set(sequential_results.keys()), (
+            f"Parallel and sequential converted different pages.\n"
+            f"Only in parallel: {set(parallel_results.keys()) - set(sequential_results.keys())}\n"
+            f"Only in sequential: {set(sequential_results.keys()) - set(parallel_results.keys())}"
+        )
+
+        for docname in sequential_results:
+            assert parallel_results[docname] == sequential_results[docname], (
+                f"Mismatch for {docname}"
+            )
+
+    def test_parallel_faster_than_sequential(self, pytorch_html_dir):
+        """Parallel conversion should not be significantly slower than sequential."""
+        tmp_path, html_files = pytorch_html_dir
+        docs = self._build_docs_list(tmp_path, html_files)
+
+        # Time sequential
+        start = time.perf_counter()
+        for doc in docs:
+            html_path = tmp_path / (doc["docname"] + ".html")
+            if html_path.is_file():
+                html_content = html_path.read_text(encoding="utf-8")
+                _html_to_markdown(html_content)
+        sequential_time = time.perf_counter() - start
+
+        # Time parallel (use a fresh copy to avoid .md conflicts)
+        tmp_path2 = tmp_path.parent / "timing_copy"
+        shutil.copytree(tmp_path, tmp_path2, dirs_exist_ok=True)
+        for md_file in tmp_path2.rglob("*.md"):
+            md_file.unlink()
+
+        app = MagicMock()
+        app.outdir = str(tmp_path2)
+
+        start = time.perf_counter()
+        _generate_md_files(app, docs)
+        parallel_time = time.perf_counter() - start
+
+        print(f"\nSequential: {sequential_time:.3f}s, Parallel: {parallel_time:.3f}s")
+        print(f"Speedup: {sequential_time / parallel_time:.2f}x")
+        print(f"Files converted: {len(docs)}")
+
+        # Parallel should not be more than 5x slower than sequential
+        # (allows for process startup overhead with small doc sets)
+        assert parallel_time < sequential_time * 5, (
+            f"Parallel ({parallel_time:.3f}s) was way slower than "
+            f"sequential ({sequential_time:.3f}s)"
+        )
+
+    def test_parallel_with_many_synthetic_files(self, tmp_path):
+        """Test parallelism with a larger synthetic dataset."""
+        num_files = 200
+        for i in range(num_files):
+            html = (
+                f"<article><h1>Page {i}</h1>"
+                f"<p>{'Content ' * 50}</p>"
+                f"<pre><code>x = {i}</code></pre>"
+                f"</article>"
+            )
+            (tmp_path / f"page_{i}.html").write_text(html, encoding="utf-8")
+
+        docs = [{"docname": f"page_{i}"} for i in range(num_files)]
+
+        app = MagicMock()
+        app.outdir = str(tmp_path)
+
+        results = _generate_md_files(app, docs)
+
+        assert len(results) == num_files
+        for i in range(num_files):
+            assert f"page_{i}" in results
+            assert f"# Page {i}" in results[f"page_{i}"]


### PR DESCRIPTION
- Parallelize HTML-to-markdown conversion using ProcessPoolExecutor for significant speedup on large doc sites (69x    
  faster on 2,563 PyTorch Python doc pages)
- Refactor `_generate_md_files` to return a dict of {docname: md_content} instead of a count, passing in-memory content  
  to `_generate_llms_full_txt` to avoid redundant disk reads                                                               
- Update tests to match the new API and add parallelism-specific tests validated against real PyTorch docs

pytorch_sphinx_theme2/llm_generation.py:                                                                               
  - Extract `_convert_single_doc()` as a top-level function (required for ProcessPoolExecutor pickling)
  - `_generate_md_files()` now uses ProcessPoolExecutor to convert docs in parallel; returns dict[docname, md_content]     
  instead of int                                                                                                    
  - `_generate_llms_full_txt()` takes the in-memory md_contents dict instead of re-reading .md files from disk             
                                                                  
tests/test_llm_markdown.py:                                                                                            
  - Fix 7 tests (`TestGenerateMdFiles`, `TestGenerateLlmsFullTxt`) to match new return types and signatures
  - Add TestParallelConversion class with 4 tests validating correctness and performance                                 
                                                                  
 ## Benchmarks                                                                                                                                                            
 
| Dataset | Pages | Sequential | Parallel | Speedup |
| --- | --- | --- | --- | --- |
| PyTorch Python docs | 2,563 | 622.5s (~10 min) | 9.0s | **69.4x** |                                        
                                                                                                                         
  All parallel results match sequential output byte-for-byte.                                                            
                                                                  
  Test plan                                                                                                              
                                                                  
  - All 37 unit tests pass (pytest `tests/test_llm_markdown.py`)                                                           
  - Parallel output matches sequential output byte-for-byte on 66 PyTorch C++ doc pages
  - Parallel output matches sequential output byte-for-byte on 2,563 PyTorch Python doc pages                            
  - Verified .md files are written to disk correctly                                                                     
  - 200-file synthetic stress test passes   

Tested against pytorch docs https://github.com/pytorch/pytorch/pull/179268                                            