### PR TITLE
Bump theme to v0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to pytorch_sphinx_theme2 are documented here.
 
+## v0.4.8
+
+### Improvements
+
+- **Parallel Markdown Generation** (PR #243) — Parallelized HTML-to-markdown
+  conversion using `ProcessPoolExecutor` for significantly faster `llms.txt`
+  builds on large doc sets. Includes automatic fallback to sequential processing
+  when multiprocessing is unavailable (e.g., sandboxed environments like Netlify).
+  Added comprehensive parallelism tests covering correctness, determinism,
+  and synthetic-scale workloads.
+
+---
+
 ## v0.4.7
 
 ### New Features

--- a/pytorch_sphinx_theme2/__init__.py
+++ b/pytorch_sphinx_theme2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.6"
+__version__ = "0.4.8"
 
 import json
 import os

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="svekars@meta.com",
     url="https://github.com/pytorch/pytorch_sphinx_theme",
     license="MIT",
-    version="0.4.7",
+    version="0.4.8",
     install_requires=[
         "pydata-sphinx-theme==0.15.4",
         "sphinx>=5.3.0,<=7.2.6",


### PR DESCRIPTION
Bumps pytorch_sphinx_theme2 to v0.4.8 and updates CHANGELOG.

## Changes
Version bump to 0.4.8 in setup.py, __init__.py, and CHANGELOG.md
Fixed __init__.py version — was stuck at 0.4.6 from a missed bump in the v0.4.7 release

## What's in v0.4.8
- Parallel Markdown Generation (PR #243) — Parallelized HTML-to-markdown conversion using ProcessPoolExecutor for significantly faster llms.txt builds on large doc sets. Includes automatic fallback to sequential processing when multiprocessing is unavailable (e.g., sandboxed environments like Netlify). Added comprehensive parallelism tests covering correctness, determinism, and synthetic-scale workloads.