### PR TITLE
Bump theme to 0.4.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to pytorch_sphinx_theme2 are documented here.
 
-## v0.4.8
+## v0.4.9
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to pytorch_sphinx_theme2 are documented here.
 
+## v0.4.8
+
+### Performance
+
+- **Optimized llms-full.txt Generation** (PR #244) — Added `llm_generate_full` theme option to skip expensive llms-full.txt generation on large builds. Uses `lxml` parser when available for faster HTML-to-markdown conversion. Capped parallel workers at 8 and added progress logging.
+
+### Bug Fixes
+
+- **Navbar Fix for Parallel Writes** (PR #245) — Fixed empty navbar when doctree disk writes are skipped (e.g., by PyTorch CI optimization PR #180177). Toctree entries are now cached during the read phase via `doctree-read` so all parallel write workers have access to navigation data.
+
+---
+
 ## v0.4.7
 
 ### New Features

--- a/pytorch_sphinx_theme2/__init__.py
+++ b/pytorch_sphinx_theme2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.6"
+__version__ = "0.4.8"
 
 import json
 import os
@@ -510,7 +510,7 @@ def setup(app):
         )
 
     return {
-        "version": "0.4.6",
+        "version": "0.4.8",
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }

--- a/pytorch_sphinx_theme2/__init__.py
+++ b/pytorch_sphinx_theme2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.8"
+__version__ = "0.4.9"
 
 import json
 import os
@@ -510,7 +510,7 @@ def setup(app):
         )
 
     return {
-        "version": "0.4.8",
+        "version": "0.4.9",
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="svekars@meta.com",
     url="https://github.com/pytorch/pytorch_sphinx_theme",
     license="MIT",
-    version="0.4.8",
+    version="0.4.9",
     install_requires=[
         "pydata-sphinx-theme==0.15.4",
         "sphinx>=5.3.0,<=7.2.6",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="svekars@meta.com",
     url="https://github.com/pytorch/pytorch_sphinx_theme",
     license="MIT",
-    version="0.4.7",
+    version="0.4.8",
     install_requires=[
         "pydata-sphinx-theme==0.15.4",
         "sphinx>=5.3.0,<=7.2.6",


### PR DESCRIPTION
## Summary                                                                                                  

- Bump version to 0.4.8 in setup.py and __init__.py 
- See CHANGELOG.md for full details

## Changes in 0.4.8
- `llm_generate_full` option to skip `llms-full.txt` on large builds
- Faster markdown conversion with `lxml` parser and capped workers
- Fixed empty navbar in parallel write builds