### PR TITLE
Bump theme to 0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to pytorch_sphinx_theme2 are documented here.
 
+## v0.4.10
+
+### Bug Fixes
+
+- **C++ Docs Navbar Bullets Fix** — Fixed top navigation bar rendering as a bulleted list in C++ docs. Wrapped fallback `generate_header_nav_html()` output in proper `<nav><ul class="bd-navbar-elements navbar-nav">` markup, and added `env-merge-info` handler to preserve toctree entries across parallel build workers.
+- **Right Nav Spacing Fix** — Fixed excessive vertical spacing between "On this page" TOC entries by switching `.page-toc .section-nav` from flex to block layout, restoring proper margin collapsing between items.
+
+---
+
 ## v0.4.9
 
 ### Performance

--- a/pytorch_sphinx_theme2/__init__.py
+++ b/pytorch_sphinx_theme2/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.4.9"
+__version__ = "0.4.10"
 
 import json
 import os
@@ -525,7 +525,7 @@ def setup(app):
         )
 
     return {
-        "version": "0.4.9",
+        "version": "0.4.10",
         "parallel_read_safe": True,
         "parallel_write_safe": True,
     }

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     author_email="svekars@meta.com",
     url="https://github.com/pytorch/pytorch_sphinx_theme",
     license="MIT",
-    version="0.4.9",
+    version="0.4.10",
     install_requires=[
         "pydata-sphinx-theme==0.15.4",
         "sphinx>=5.3.0,<=7.2.6",


### PR DESCRIPTION
Fixes two visual regressions in the docs navigation:

* Fixed C++ docs top navbar rendered as a bulleted list.
* Fixed right nav large space by setting `.page-toc .section-nav { display: block; }.`

## Test plan

* Build C++ docs: https://docs-preview.pytorch.org/pytorch/pytorch/183505/cppdocs/index.html
* Build Python docs: https://docs-preview.pytorch.org/pytorch/pytorch/183505/index.html
* Check pages widdddth long TOC titles like: https://docs-preview.pytorch.org/pytorch/pytorch/183505/torch.html