### PR TITLE
Fix dropdown width and add MyST directives test page

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,17 @@ extensions = [
 myst_enable_extensions = [
     "colon_fence",
     "deflist",
+    "fieldlist",
+    "substitution",
+    "tasklist",
+    "attrs_inline",
+    "attrs_block",
 ]
+
+myst_substitutions = {
+    "project_name": "PyTorch",
+    "version_num": "2.0",
+}
 
 print(
     f"HAS_SPHINX_GALLERY value: {pytorch_sphinx_theme2.custom_directives.HAS_SPHINX_GALLERY}"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,7 @@ Welcome to PyTorch Sphinx Theme 2 Docs
     :caption: Test Pages
 
     test-myst
+    test-myst-directives
     test-cards
     test-glossary
     test_tutorials_landing_page

--- a/docs/test-myst-directives.md
+++ b/docs/test-myst-directives.md
@@ -1,0 +1,333 @@
+# MyST Directives Test Page
+
+This page tests all common MyST and sphinx-design directives to verify they render
+correctly with the PyTorch Sphinx theme.
+
+## Dropdowns
+
+### Basic Dropdown
+
+```{dropdown} More details on mutation and aliasing
+`custom_op` asks for a precise mutation and aliasing contract because PyTorch
+uses that contract in `FakeTensor`, `autograd`, `functionalization`, and
+`torch.compile`.
+
+For a functional `custom_op`, PyTorch assumes the operator does not mutate
+any input and that returned tensors are fresh values. This is the easiest
+kind of op to set up for `torch.compile`.
+
+For an in-place `custom_op`, `torch.Tag.inplace` gives PyTorch a stronger
+and more specific contract: the first argument and the returned object are
+the same object. This lets PyTorch derive the fake-tensor behavior from
+the schema instead of requiring a separate fake kernel.
+```
+
+### Dropdown with Title and Open by Default
+
+```{dropdown} Click to expand this section
+:open:
+
+This dropdown is open by default. It contains some code:
+
+    import torch
+    x = torch.randn(3, 4)
+    print(x)
+```
+
+### Dropdown with Admonition Style
+
+```{dropdown} Important implementation note
+:color: warning
+
+This is a dropdown styled as a warning. Be careful when using this API
+as it may change in future versions.
+
+- Point one about the API
+- Point two about compatibility
+- Point three about deprecation timeline
+```
+
+```{dropdown} Tip: Performance optimization
+:color: success
+
+Use `torch.compile` for best performance:
+
+    model = torch.compile(model)
+```
+
+## Admonitions
+
+```{note}
+This is a note admonition. Use it to highlight important information.
+```
+
+```{warning}
+This is a warning. Proceed with caution when using experimental APIs.
+```
+
+```{tip}
+Use `torch.no_grad()` context manager to disable gradient computation
+during inference for better performance.
+```
+
+```{important}
+Always call `model.eval()` before inference and `model.train()` before training.
+```
+
+```{caution}
+Mixing CPU and CUDA tensors in operations will raise a `RuntimeError`.
+```
+
+```{danger}
+Never store sensitive data in model checkpoint files without encryption.
+```
+
+```{seealso}
+See the [PyTorch documentation](https://pytorch.org/docs/) for more details.
+```
+
+```{hint}
+You can use `torch.cuda.is_available()` to check for GPU availability.
+```
+
+### Custom Titled Admonition
+
+```{admonition} Custom Title Here
+:class: tip
+
+This is an admonition with a custom title styled as a tip.
+```
+
+## Tab Sets
+
+````{tab-set}
+
+```{tab-item} Python
+Use Python for most deep learning tasks:
+
+    import torch
+    x = torch.tensor([1.0, 2.0, 3.0])
+```
+
+```{tab-item} C++
+Use the C++ frontend for production:
+
+    #include <torch/torch.h>
+    auto x = torch::tensor({1.0, 2.0, 3.0});
+```
+
+```{tab-item} CLI
+Use the CLI for quick experiments:
+
+    python -m torch.utils.benchmark
+```
+````
+
+## Cards
+
+### Standalone Card
+
+```{card} Getting Started with PyTorch
+:link: https://pytorch.org/tutorials/
+:link-type: url
+
+Learn the basics of PyTorch with our beginner tutorials. Covers tensors,
+autograd, neural networks, and more.
++++
+Footer content
+```
+
+### Card Grid
+
+::::{grid} 2
+:::{grid-item-card} Training
+:link: https://pytorch.org
+:link-type: url
+:class-card: card-prerequisites
+
+Learn how to train models with PyTorch.
+:::
+
+:::{grid-item-card} Deployment
+:link: https://pytorch.org
+:link-type: url
+:class-card: card-prerequisites
+
+Deploy models to production with TorchServe.
+:::
+::::
+
+## Badges and Buttons
+
+{bdg}`plain badge`
+{bdg-primary}`primary`
+{bdg-secondary}`secondary`
+{bdg-success}`success`
+{bdg-warning}`warning`
+{bdg-danger}`danger`
+{bdg-info}`info`
+{bdg-light}`light`
+{bdg-dark}`dark`
+
+### Outline Badges
+
+{bdg-primary-line}`primary outline`
+{bdg-warning-line}`warning outline`
+{bdg-success-line}`success outline`
+
+### Buttons
+
+```{button-link} https://pytorch.org
+:color: primary
+
+Go to PyTorch
+```
+
+```{button-link} https://pytorch.org/docs/
+:color: secondary
+:outline:
+
+View Documentation
+```
+
+## Definition Lists
+
+Term 1
+: Definition of the first term. This can span
+  multiple lines.
+
+Term 2
+: Definition of the second term.
+
+`torch.Tensor`
+: The main data structure in PyTorch. A multi-dimensional matrix
+  containing elements of a single data type.
+
+## Field Lists
+
+:Author: PyTorch Team
+:Version: 2.0
+:Status: Stable
+:License: BSD-3
+
+## Task Lists
+
+- [x] Install PyTorch
+- [x] Set up development environment
+- [ ] Train first model
+- [ ] Deploy to production
+
+## Substitutions
+
+This project is called {{project_name}} version {{version_num}}.
+
+## Code Blocks
+
+```{code-block} python
+:linenos:
+:emphasize-lines: 2, 4
+
+import torch
+import torch.nn as nn
+
+model = nn.Linear(10, 5)
+x = torch.randn(3, 10)
+output = model(x)
+print(output.shape)
+```
+
+```{code-block} bash
+:caption: Installation command
+
+pip install torch torchvision torchaudio
+```
+
+## Math
+
+```{math}
+\nabla_\theta J(\theta) = \mathbb{E}_{\pi_\theta} \left[ \sum_{t=0}^{T} \nabla_\theta \log \pi_\theta(a_t|s_t) \cdot G_t \right]
+```
+
+Inline math: {math}`E = mc^2`
+
+## Tables
+
+```{list-table} Comparison of Optimizers
+:header-rows: 1
+:widths: 20 40 20 20
+
+* - Optimizer
+  - Description
+  - Learning Rate
+  - Momentum
+* - SGD
+  - Stochastic Gradient Descent
+  - 0.01
+  - 0.9
+* - Adam
+  - Adaptive Moment Estimation
+  - 0.001
+  - N/A
+* - AdamW
+  - Adam with weight decay
+  - 0.001
+  - N/A
+```
+
+## Figures
+
+```{figure} https://pytorch.org/assets/images/pytorch-logo.png
+:alt: PyTorch Logo
+:width: 200px
+:align: center
+
+The PyTorch logo.
+```
+
+## Block Attributes
+
+The `attrs_block` extension lets you attach HTML attributes (classes, IDs) to
+the next block element using `{.classname}` or `{#id}` syntax.
+
+{.sd-text-primary}
+This paragraph is styled with the `sd-text-primary` class via attrs_block.
+
+{.sd-bg-light .sd-p-3 .sd-rounded-3}
+This paragraph has a light background, padding, and rounded corners.
+
+## Toggles (Nested Dropdowns)
+
+::::{dropdown} Outer dropdown
+This is the outer content.
+
+:::{dropdown} Inner dropdown
+This is nested inside the outer dropdown.
+:::
+::::
+
+## Sphinx-Design Containers
+
+::::{grid} 3
+:gutter: 2
+
+:::{grid-item}
+:columns: 12 6 6 4
+
+### Column 1
+Content in the first column of a responsive grid.
+:::
+
+:::{grid-item}
+:columns: 12 6 6 4
+
+### Column 2
+Content in the second column.
+:::
+
+:::{grid-item}
+:columns: 12 12 12 4
+
+### Column 3
+Content in the third column. On mobile, all columns stack vertically.
+:::
+::::

--- a/pytorch_sphinx_theme2/static/css/theme.css
+++ b/pytorch_sphinx_theme2/static/css/theme.css
@@ -403,6 +403,10 @@ html[data-theme=dark] {
   margin-left: 5px;
 }
 
+.navbar-header-items__center .navbar-item li.nav-item {
+  list-style: none;
+}
+
 .bd-header {
   top: var(--header-height-desktop) !important;
   position: sticky !important;
@@ -2607,6 +2611,7 @@ a.btn {
   appearance: none;
   background: transparent;
   border: 1px solid var(--pst-color-background);
+  width: 1.3125rem;
   height: 1.3125rem;
   position: absolute;
   bottom: 42px;
@@ -2614,6 +2619,22 @@ a.btn {
   top: 0;
   cursor: pointer;
   outline: none;
+  padding: 0;
+}
+.cookie-banner-wrapper .close-button::before, .cookie-banner-wrapper .close-button::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  height: 2px;
+  background-color: #ee4c2a;
+}
+.cookie-banner-wrapper .close-button::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+.cookie-banner-wrapper .close-button::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
 }
 @media screen and (min-width: 768px) {
   .cookie-banner-wrapper .close-button {
@@ -3051,12 +3072,17 @@ nav.bd-links li > a {
   color: var(--pst-color-text-base) !important;
 }
 
+.toc-entry a.nav-link, .toc-entry a > code {
+  color: var(--pst-color-text-base) !important;
+}
+
 .page-toc .section-nav {
   display: block;
 }
 
-.toc-entry a.nav-link, .toc-entry a > code {
-  color: var(--pst-color-text-base) !important;
+.bd-sidebar-secondary .toc-entry a.nav-link {
+  padding-top: 0.125rem;
+  padding-bottom: 0.125rem;
 }
 
 .bd-sidebar-primary {
@@ -3826,6 +3852,16 @@ html[data-theme=dark] {
 .sd-card:hover:after {
   transform: scaleX(1);
 }
+.sd-card.sd-dropdown {
+  width: 100%;
+  max-width: 100%;
+}
+.sd-card.sd-dropdown:after {
+  display: none;
+}
+.sd-card.sd-dropdown:hover:after {
+  transform: none;
+}
 
 @media (max-width: 767px) {
   .sd-row[class*=sd-row-cols-] {
@@ -3864,6 +3900,9 @@ html[data-theme=dark] {
   }
   .sd-card {
     max-width: 500px;
+  }
+  .sd-card.sd-dropdown {
+    max-width: 100%;
   }
 }
 .sd-card-img {
@@ -4087,6 +4126,64 @@ span.highlighted {
     background-attachment: local, scroll;
   }
 }
+/*
+ * Collapsible "Subclassed by" list styles.
+ * When a paragraph has more than 5 links, it collapses to a single line
+ * with a "See All" button to expand the full list.
+ * Main use case is C++ docs
+ */
+/* Container for the subclassed-by list */
+.subclassed-by-list {
+  position: relative;
+  /* Initially collapsed state - show only 1 line */
+}
+.subclassed-by-list.collapsed {
+  max-height: 1.6em;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 140px; /* Space for the button */
+}
+.subclassed-by-list {
+  /* Expanded state */
+}
+.subclassed-by-list.expanded {
+  max-height: none;
+  overflow: visible;
+  white-space: normal;
+  padding-right: 0;
+  padding-bottom: 2em; /* Space for the button at the bottom */
+}
+.subclassed-by-list.expanded .subclassed-by-toggle {
+  position: absolute;
+  top: auto;
+  bottom: 0;
+  right: 0;
+}
+
+/* The "See All" / "Hide" toggle button */
+.subclassed-by-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 2px 10px;
+  color: #333;
+  cursor: pointer;
+  font-size: 0.85em;
+  text-decoration: none;
+  font-family: inherit;
+  font-weight: 500;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+.subclassed-by-toggle:hover {
+  background-color: #e0e0e0;
+  border-color: #999;
+  text-decoration: none;
+}
+
 /*!
  * Font Awesome Free 6.7.2 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)

--- a/pytorch_sphinx_theme2/static/scss/_sphinx_design.scss
+++ b/pytorch_sphinx_theme2/static/scss/_sphinx_design.scss
@@ -68,6 +68,20 @@ html[data-theme="dark"] {
       transform: scaleX(1);
     }
   }
+
+  // Dropdowns should span full width, not be constrained like cards
+  &.sd-dropdown {
+    width: 100%;
+    max-width: 100%;
+
+    &:after {
+      display: none;
+    }
+
+    &:hover:after {
+      transform: none;
+    }
+  }
 }
 
 // Sphinx-design grid mobile responsiveness
@@ -121,6 +135,10 @@ html[data-theme="dark"] {
 
   .sd-card {
     max-width: 500px;
+
+    &.sd-dropdown {
+      max-width: 100%;
+    }
   }
 }
 


### PR DESCRIPTION
- Fix sphinx-design `{dropdown}` directives rendering at only 30% page width instead of full article width
- Add comprehensive test page (`test-myst-directives.md`) covering all common MyST and sphinx-design
  directives

## The issue
`.sd-card` in `_sphinx_design.scss` sets `width: 30%` and `max-width: 500px` for card grid layouts. Sphinx-design renders dropdowns as `.sd-card.sd-dropdown`, so dropdowns inherited these card width constraints and appeared as a narrow strip instead of spanning the full content area. See [here](https://docs-preview.pytorch.org/pytorch/pytorch/184205/library.html#choosing-the-kind-of-custom-op) - scroll down to dropdown. 

## The Fix
Added `.sd-card.sd-dropdown` overrides in `_sphinx_design.scss` that set `width: 100%` and `max-width: 100%`, and disable the card hover underline animation on dropdowns. The selector is specific to elements with both classes, so regular cards in grids are unaffected.

 ## Test plan
- [X] Build theme: `npx grunt default`
- [X] Build docs: `cd docs && python3 -m sphinx -b html . _build/html`
- [X] Verify dropdowns span full article width on `test-myst-directives.html`
- [X] Verify existing cards on `test-cards.html` are unchanged (still 30% width in grids)
- [X] Check dropdown behavior at mobile, tablet, and desktop breakpoints
- [X] Test against pytorch docs: https://github.com/pytorch/pytorch/pull/184425: Preview looks good: https://docs-preview.pytorch.org/pytorch/pytorch/184425/library.html